### PR TITLE
fix: render proxy keys without innerHTML

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -1814,25 +1814,114 @@ async function handler(req: Request): Promise<Response> {
         }
 
         if (data.keys?.length > 0) {
-          container.innerHTML = data.keys.map(k => \`
-            <div class="list-item">
-              <div class="item-info">
-                <div class="item-primary">
-                  <span class="key-text" id="pk-\${k.id}">\${k.key}</span>
-                  <button class="btn-icon" onclick="toggleProxyKeyVisibility('\${k.id}')" title="查看完整密钥">
-                    <svg id="pk-eye-\${k.id}" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                    <svg id="pk-eye-off-\${k.id}" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none;"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
-                  </button>
-                </div>
-                <div class="item-secondary">\${k.name} · 已使用 \${k.useCount} 次</div>
-              </div>
-              <div class="item-actions">
-                <button class="btn btn-outline" onclick="copyProxyKey('\${k.id}')">复制</button>
-                <button class="btn btn-danger" onclick="deleteProxyKey('\${k.id}')">删除</button>
-              </div>
-            </div>\`).join('');
+          container.textContent = '';
+
+          for (const k of data.keys) {
+            const item = document.createElement('div');
+            item.className = 'list-item';
+
+            const info = document.createElement('div');
+            info.className = 'item-info';
+
+            const primary = document.createElement('div');
+            primary.className = 'item-primary';
+
+            const keySpan = document.createElement('span');
+            keySpan.className = 'key-text';
+            keySpan.id = 'pk-' + k.id;
+            keySpan.textContent = String(k.key ?? '');
+
+            const toggleBtn = document.createElement('button');
+            toggleBtn.className = 'btn-icon';
+            toggleBtn.title = '查看完整密钥';
+            toggleBtn.addEventListener('click', () => toggleProxyKeyVisibility(k.id));
+
+            const svgNs = 'http://www.w3.org/2000/svg';
+
+            const eyeIcon = document.createElementNS(svgNs, 'svg');
+            eyeIcon.id = 'pk-eye-' + k.id;
+            eyeIcon.setAttribute('xmlns', svgNs);
+            eyeIcon.setAttribute('width', '12');
+            eyeIcon.setAttribute('height', '12');
+            eyeIcon.setAttribute('viewBox', '0 0 24 24');
+            eyeIcon.setAttribute('fill', 'none');
+            eyeIcon.setAttribute('stroke', 'currentColor');
+            eyeIcon.setAttribute('stroke-width', '2');
+
+            const eyePath = document.createElementNS(svgNs, 'path');
+            eyePath.setAttribute('d', 'M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z');
+
+            const eyeCircle = document.createElementNS(svgNs, 'circle');
+            eyeCircle.setAttribute('cx', '12');
+            eyeCircle.setAttribute('cy', '12');
+            eyeCircle.setAttribute('r', '3');
+
+            eyeIcon.appendChild(eyePath);
+            eyeIcon.appendChild(eyeCircle);
+
+            const eyeOffIcon = document.createElementNS(svgNs, 'svg');
+            eyeOffIcon.id = 'pk-eye-off-' + k.id;
+            eyeOffIcon.setAttribute('xmlns', svgNs);
+            eyeOffIcon.setAttribute('width', '12');
+            eyeOffIcon.setAttribute('height', '12');
+            eyeOffIcon.setAttribute('viewBox', '0 0 24 24');
+            eyeOffIcon.setAttribute('fill', 'none');
+            eyeOffIcon.setAttribute('stroke', 'currentColor');
+            eyeOffIcon.setAttribute('stroke-width', '2');
+            eyeOffIcon.style.display = 'none';
+
+            const eyeOffPath = document.createElementNS(svgNs, 'path');
+            eyeOffPath.setAttribute('d', 'M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24');
+
+            const eyeOffLine = document.createElementNS(svgNs, 'line');
+            eyeOffLine.setAttribute('x1', '1');
+            eyeOffLine.setAttribute('y1', '1');
+            eyeOffLine.setAttribute('x2', '23');
+            eyeOffLine.setAttribute('y2', '23');
+
+            eyeOffIcon.appendChild(eyeOffPath);
+            eyeOffIcon.appendChild(eyeOffLine);
+
+            toggleBtn.appendChild(eyeIcon);
+            toggleBtn.appendChild(eyeOffIcon);
+
+            primary.appendChild(keySpan);
+            primary.appendChild(toggleBtn);
+
+            const secondary = document.createElement('div');
+            secondary.className = 'item-secondary';
+            secondary.textContent = String(k.name ?? '') + ' · 已使用 ' + String(k.useCount ?? 0) + ' 次';
+
+            info.appendChild(primary);
+            info.appendChild(secondary);
+
+            const actions = document.createElement('div');
+            actions.className = 'item-actions';
+
+            const copyBtn = document.createElement('button');
+            copyBtn.className = 'btn btn-outline';
+            copyBtn.textContent = '复制';
+            copyBtn.addEventListener('click', () => copyProxyKey(k.id));
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.className = 'btn btn-danger';
+            deleteBtn.textContent = '删除';
+            deleteBtn.addEventListener('click', () => deleteProxyKey(k.id));
+
+            actions.appendChild(copyBtn);
+            actions.appendChild(deleteBtn);
+
+            item.appendChild(info);
+            item.appendChild(actions);
+
+            container.appendChild(item);
+          }
         } else {
-          container.innerHTML = '<div class="empty-state">暂无代理密钥，API 当前为公开访问</div>';
+          container.textContent = '';
+          const empty = document.createElement('div');
+          empty.className = 'empty-state';
+          empty.textContent = '暂无代理密钥，API 当前为公开访问';
+          container.appendChild(empty);
         }
       } catch (e) { showNotification('加载失败: ' + e.message, 'error'); }
     }


### PR DESCRIPTION
Fixes #15.

### What
- Replace `innerHTML` template rendering in `loadProxyKeys()` with DOM construction.
- Bind events via `addEventListener`.
- Use `textContent` for all dynamic fields.

### Why
- Prevent XSS injection via proxy key data.

### Verification
- `deno fmt --check deno.ts`
- `deno lint deno.ts deno_test.ts`
- `deno test deno_test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了列表渲染机制，改进了性能和代码结构的一致性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->