### PR TITLE
ci: add Deno CI and publish bundle branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: ci
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+permissions:
+  contents: write
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v2.x
+      - name: deno fmt --check
+        run: deno fmt --check deno.ts deno_test.ts
+      - name: deno lint
+        run: deno lint deno.ts deno_test.ts
+      - name: deno check
+        run: deno check deno.ts deno_test.ts
+      - name: deno test
+        run: deno test deno_test.ts
+  publish_bundle:
+    needs: [quality]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v2.x
+      - name: Bundle
+        run: |
+          rm -rf dist .bundle-artifacts
+          mkdir -p dist .bundle-artifacts
+          deno bundle deno.ts -o dist/deno.bundle.js
+          deno bundle deno.ts -o dist/deno.bundle.min.js --minify
+          cp -r dist .bundle-artifacts/dist
+      - name: Publish to bundle branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout --orphan bundle
+          git rm -rf .
+
+          rm -rf dist
+          cp -r .bundle-artifacts/dist dist
+          rm -rf .bundle-artifacts
+
+          cat > README.md <<'EOF'
+          # Deploy artifact (bundle)
+
+          This branch contains single-file bundle artifacts for Deno Deploy copy/paste.
+
+          Files:
+          - dist/deno.bundle.js (readable)
+          - dist/deno.bundle.min.js (minified, recommended)
+          EOF
+
+          git add dist README.md
+
+          if git diff --cached --quiet; then
+            echo "No changes to publish"
+            exit 0
+          fi
+
+          git commit -m "chore(bundle): update deploy artifacts"
+          git push -f origin bundle

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@
 
 2. 部署到 Deno:
    * 打开 [Deno Deploy](https://dash.deno.com/) 并新建 `Playground`。
-   * 把 `deno.ts` 的代码粘贴进去并部署。
+   * **傻瓜版（推荐）**：打开下面任意一个文件，全选复制后粘贴到 Playground 并部署：
+     * `dist/deno.bundle.min.js`（推荐，体积更小）：https://github.com/zhu-jl18/thanks-to-cerebras/blob/bundle/dist/deno.bundle.min.js
+     * `dist/deno.bundle.js`（可读版本）：https://github.com/zhu-jl18/thanks-to-cerebras/blob/bundle/dist/deno.bundle.js
+   * **开发者版**：直接把 `deno.ts` 的代码粘贴进去并部署（或使用 GitHub 绑定部署）。
    * (Optional) 配置环境变量`KV_FLUSH_INTERVAL_MS=<刷盘间隔ms>`，默认 15000。
     <div align="center">
       <p>Deno Deploy 配置</p>


### PR DESCRIPTION
Fixes #18.

### What
- Add GitHub Actions workflow running:
  - `deno fmt --check`
  - `deno lint`
  - `deno check`
  - `deno test`
- On every push to `main`, generate single-file deploy artifacts via `deno bundle` and publish them to the `bundle` branch.
- Update README with “傻瓜版” copy/paste deploy instructions.

### Why
- Keep main green with enforceable quality gates.
- Provide a copy/paste single-file artifact for Deno Deploy Playground users.

### Notes
- Workflow only triggers on `main` pushes / PRs to `main` (bundle branch pushes will not loop).