### PR TITLE
refactor: remove currentKeyIndex from config

### DIFF
--- a/TECH_DETAILS.md
+++ b/TECH_DETAILS.md
@@ -45,7 +45,7 @@ async function isProxyAuthorized(req: Request) {
   modelPool: string[],
   currentModelIndex: number,
   totalRequests: number,
-  schemaVersion: '3.0'
+  schemaVersion: '3.1'
 }
 
 // 管理员密码

--- a/deno.ts
+++ b/deno.ts
@@ -74,7 +74,6 @@ interface ProxyAuthKey {
 interface ProxyConfig {
   modelPool: string[];
   currentModelIndex: number;
-  currentKeyIndex: number;
   totalRequests: number;
   schemaVersion: string;
 }
@@ -400,9 +399,8 @@ async function kvEnsureConfigEntry(): Promise<Deno.KvEntry<ProxyConfig>> {
     const defaultConfig: ProxyConfig = {
       modelPool: [...DEFAULT_MODEL_POOL],
       currentModelIndex: 0,
-      currentKeyIndex: 0,
       totalRequests: 0,
-      schemaVersion: "3.0",
+      schemaVersion: "3.1",
     };
     await kv.set(CONFIG_KEY, defaultConfig);
     entry = await kv.get<ProxyConfig>(CONFIG_KEY);


### PR DESCRIPTION
Fixes #14.

### What
- Remove unused `currentKeyIndex` from `ProxyConfig`.
- Stop writing `currentKeyIndex` in default config.
- Bump `schemaVersion` to 3.1 and align docs.

### Verification
- `deno lint deno.ts deno_test.ts src/*.ts`
- `deno test deno_test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **维护（Chores）**
  * 更新了配置架构版本（3.0 → 3.1），以增强系统兼容性
  * 优化了配置初始化流程，移除了不必要的内部追踪机制，提升系统运行效率

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->