### PR TITLE
Fixes #34: /api 错误返回采用 Problem Details

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -7,8 +7,10 @@
 - `OPTIONS` 预检请求统一返回 `204`。
 - JSON 响应默认带 `Cache-Control: no-store`（用于避免缓存敏感数据/统计）。
 
-> 注意：管理 API（`/api/*`）目前错误返回主要是 `{ "error": string }`。
-> 我们已经创建 issue #34，计划将所有非 2xx 错误统一升级到更标准的 Problem Details（`application/problem+json`）。
+> 管理 API（`/api/*`）的非 2xx 错误采用 Problem Details：
+>
+> - `Content-Type: application/problem+json`
+> - Body: `{ type, title, status, detail, instance? }`
 
 ## 1. 鉴权模型
 
@@ -38,6 +40,7 @@
   - 流式响应会直接透传上游 response body
 
 常见响应码：
+
 - `401`：代理访问未授权（启用了代理密钥但没带/带错 Bearer token）
 - `429`：当前没有可用 API key（全部处于冷却/不可用等）
 


### PR DESCRIPTION
Fixes #34

- /api/* 非 2xx 错误：统一返回 Problem Details（pplication/problem+json，字段 	ype/title/status/detail/instance）
- 管理面板前端：统一基于 es.ok 处理失败分支，并优先展示 detail
- docs/API.md 同步更新

备注：/v1 保持 OpenAI 兼容优先（错误仍为 {error: string}）。

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * API错误响应统一为标准格式，提供更一致的错误消息展示
  * 前端错误处理机制优化，包含更详细的上下文信息

* **Bug修复**
  * 改进了未授权响应的处理流程，自动清除过期凭证
  * 增强了错误消息的用户友好性和可读性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->