### PR TITLE
feat: configurable KV flush interval (min 1000ms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@
      * `dist/deno.bundle.min.js`（推荐，体积更小）：https://github.com/zhu-jl18/thanks-to-cerebras/blob/bundle/dist/deno.bundle.min.js
      * `dist/deno.bundle.js`（可读版本）：https://github.com/zhu-jl18/thanks-to-cerebras/blob/bundle/dist/deno.bundle.js
    * **开发者版**：直接把 `deno.ts` 的代码粘贴进去并部署（或使用 GitHub 绑定部署）。
-   * (Optional) 配置环境变量`KV_FLUSH_INTERVAL_MS=<刷盘间隔ms>`，默认 15000。
+   * (Optional) 配置环境变量`KV_FLUSH_INTERVAL_MS=<刷盘间隔ms>`（默认 15000；最小 1000；会覆盖面板配置）。
+   * 也可以在管理面板「访问控制」→「高级设置」里修改刷盘间隔。
     <div align="center">
       <p>Deno Deploy 配置</p>
       <img src="image/配置说明1.png" alt="Deno Deploy" width="70%">

--- a/docs/API.md
+++ b/docs/API.md
@@ -115,3 +115,9 @@
 
 - `GET /api/stats`
 - `GET /api/config`
+  - 返回配置（包含 KV 刷盘相关字段：`kvFlushIntervalMs` /
+    `effectiveKvFlushIntervalMs` / `kvFlushIntervalSource` /
+    `kvFlushIntervalMinMs`）
+- `PATCH /api/config`
+  - 请求体：`{ "kvFlushIntervalMs": number }`
+  - 用途：更新 KV 刷盘间隔（会被钳制到最小值）

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -10,17 +10,25 @@
 ## 部署流程
 
 ### 1. 创建项目
-在 [Deno Deploy](https://dash.deno.com/) 点击 "New Project" → "Deploy from Dashboard"
+
+在 [Deno Deploy](https://dash.deno.com/) 点击 "New Project" → "Deploy from
+Dashboard"
 
 ### 2. 粘贴源码
+
 将 `deno.ts` 整体拷贝到在线编辑器，保存并 Deploy
 
 ### 3. 配置环境变量（可选）
+
 在 "Settings > Environment Variables" 中追加：
-- `KV_FLUSH_INTERVAL_MS=<刷盘间隔ms>`（可选，默认 15000）
+
+- `KV_FLUSH_INTERVAL_MS=<刷盘间隔ms>`（可选，默认 15000；最小
+  1000；会覆盖面板配置）
 
 ### 4. 验证部署
+
 访问日志，应看到：
+
 ```
 Cerebras Proxy 启动
 - 管理面板: /
@@ -30,6 +38,7 @@ Cerebras Proxy 启动
 ```
 
 ### 5. 首次配置
+
 1. 浏览器打开 `https://<project>.deno.dev/`
 2. 设置管理密码（至少 4 位）
 3. 登录后添加 Cerebras API 密钥
@@ -38,11 +47,13 @@ Cerebras Proxy 启动
 ## 运维说明
 
 ### 管理面板
+
 - 首次访问必须设置密码
 - 登录会话有效期 7 天（过期后需重新输入密码，管理密码本身永久有效）
 - 三个标签页：访问控制、API 密钥、模型配置
 
 ### 访问控制
+
 - 无代理密钥时：公开访问
 - 有代理密钥时：需 Bearer token 鉴权
 - 最多 5 个代理密钥
@@ -51,8 +62,10 @@ Cerebras Proxy 启动
 
 默认每 15 秒将统计数据异步写回 KV，最终一致。
 
-- 可通过环境变量 `KV_FLUSH_INTERVAL_MS` 调整刷盘间隔（建议 >= 1000ms）。
-- 不要把它设为 `0`：当前实现里 `0` 会关闭定时刷盘，导致统计/用量等脏数据不落库。
+- 推荐在管理面板「访问控制」→「高级设置」里调整刷盘间隔。
+- 也可通过环境变量 `KV_FLUSH_INTERVAL_MS` 覆盖（优先级更高）。
+- 刷盘间隔会被钳制到 **最小 1000ms**（例如设置成 `0` 或 `500` 最终都会按
+  `1000ms` 执行）。
 
 ## 客户端配置
 
@@ -64,11 +77,8 @@ Model: 任意
 
 ## 常见问题
 
-**"没有可用的 API 密钥"**
-至少保留一个状态为 active 的 Cerebras API 密钥。
+**"没有可用的 API 密钥"** 至少保留一个状态为 active 的 Cerebras API 密钥。
 
-**401 Unauthorized**
-检查是否创建了代理密钥，客户端是否携带正确的 Bearer token。
+**401 Unauthorized** 检查是否创建了代理密钥，客户端是否携带正确的 Bearer token。
 
-**统计数据跳变**
-多实例部署时各实例不共享内存缓存，统计受刷盘间隔影响。
+**统计数据跳变** 多实例部署时各实例不共享内存缓存，统计受刷盘间隔影响。


### PR DESCRIPTION
- KV_FLUSH_INTERVAL_MS 取整并钳制到最小 1000ms（避免 0 误关刷盘）
- ProxyConfig 增加 kvFlushIntervalMs，新增 PATCH /api/config
- 管理面板新增「访问控制」→「高级设置」可视化修改刷盘间隔
- README / docs 同步更新

Co-Authored-By: Warp <agent@warp.dev>