### PR TITLE
fix: 默认模型池移除 zai-glm-4.6

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -164,7 +164,6 @@ interface ProxyConfig {
 const DEFAULT_MODEL_POOL = [
   "gpt-oss-120b",
   "qwen-3-235b-a22b-instruct-2507",
-  "zai-glm-4.6",
   "zai-glm-4.7",
 ];
 const FALLBACK_MODEL = "qwen-3-235b-a22b-instruct-2507";


### PR DESCRIPTION
Fixes #41

- 移除已下架/无权限模型，避免轮询到该模型时上游返回 model_not_found (404)

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores（杂务）**
  * 调整了默认模型配置列表，优化系统设置。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->