### PR TITLE
feat: 模型目录 catalog API（public models）

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -104,6 +104,16 @@
 
 ### 4.3 模型池（Models）
 
+模型目录（Catalog）：
+
+- `GET /api/models/catalog`
+  - 描述：从 Cerebras public models API 拉取并缓存“可用模型列表”。
+  - 返回：`models`、`fetchedAt`、`ttlMs`、`stale`、`lastError?`
+- `POST /api/models/catalog/refresh`
+  - 描述：强制刷新模型目录。
+
+模型池（Pool）：
+
 - `GET /api/models`
 - `POST /api/models`
   - 请求体：`{ "model": string }`


### PR DESCRIPTION
Fixes #45

- 新增 /api/models/catalog（可用模型目录，含缓存状态）
- 新增 /api/models/catalog/refresh（强制刷新）
- 文档补齐

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 添加模型目录管理功能：新增 GET /api/models/catalog 端点获取并缓存可用模型列表；新增 POST /api/models/catalog/refresh 端点强制刷新目录，返回模型数据、获取时间戳和缓存状态信息

## 文档
* 更新API文档记录新增的模型目录端点及其响应数据结构

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->