### PR TITLE
feat: 模型池勾选式编辑（基于 catalog）

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -115,6 +115,9 @@
 模型池（Pool）：
 
 - `GET /api/models`
+- `PUT /api/models`
+  - 描述：一次性更新模型池（会去重/trim）。
+  - 请求体：`{ "models": string[] }`
 - `POST /api/models`
   - 请求体：`{ "model": string }`
 - `DELETE /api/models/<name>`


### PR DESCRIPTION
Fixes #46

- Models 标签页新增「可用模型目录」+ 搜索/刷新
- 通过 checkbox 勾选并一次性保存模型池（PUT /api/models）
- 保留手动添加自定义模型入口

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 新增模型目录浏览与管理功能，支持搜索过滤
  * 支持手动添加和管理自定义模型
  * 增加"保存模型池"操作，允许用户快速更新当前模型配置
  * 模型池为空时显示提示信息

* **文档**
  * 新增 PUT /api/models API 端点文档，支持批量更新和去重模型池

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->