### PR TITLE
feat: support PORT for non-deploy runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ sequenceDiagram
 deno run --allow-net --allow-env --allow-read --allow-write main.ts
 ```
 
+默认监听 8000 端口，可通过环境变量 `PORT` 更改（例：`PORT=8339`）。
+
 本地 KV 数据默认存储在 `src/.deno-kv-local/kv.sqlite3`，可通过环境变量
 `KV_PATH` 指定目录（例：`KV_PATH=./data`）。
 

--- a/docs/DEPLOYMENT_DOCKER.md
+++ b/docs/DEPLOYMENT_DOCKER.md
@@ -11,7 +11,24 @@ cd thanks-to-cerebras
 docker compose up -d
 ```
 
-访问 `http://localhost:8000` 进入管理面板。
+默认访问 `http://localhost:8000` 进入管理面板。
+
+## 端口配置
+
+Docker 端口映射格式为：
+
+```
+<宿主机端口>:<容器端口>
+```
+
+本项目容器内默认监听 8000（可通过 `PORT` 调整，但通常不需要）。最常见的做法是只改“宿主机端口”，例如：
+
+```yaml
+ports:
+  - "8339:8000"
+```
+
+此时访问 `http://localhost:8339`。
 
 ## 数据持久化
 

--- a/docs/DEPLOYMENT_VPS.md
+++ b/docs/DEPLOYMENT_VPS.md
@@ -28,6 +28,12 @@ cd thanks-to-cerebras
 deno task start
 ```
 
+默认监听 8000 端口，可通过 `PORT` 更改：
+
+```bash
+PORT=8339 deno task start
+```
+
 ## KV 数据存储
 
 默认存储在项目目录下：
@@ -70,6 +76,7 @@ User=cerebras-proxy
 Group=cerebras-proxy
 WorkingDirectory=/opt/cerebras-proxy/app
 Environment=KV_PATH=/var/lib/cerebras-proxy
+Environment=PORT=8339
 ExecStart=/usr/local/bin/deno task start
 Restart=always
 RestartSec=5

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -41,7 +41,7 @@ cd thanks-to-cerebras
 deno task dev
 ```
 
-访问 `http://localhost:8000` 进入管理面板。
+默认访问 `http://localhost:8000` 进入管理面板（或你设置的 `PORT`）。
 
 ## deno task 命令
 
@@ -159,7 +159,18 @@ KV_PATH=/custom/path deno task dev
 
 **端口被占用**
 
-默认监听 8000 端口，如需更改可修改 `main.ts` 中的端口配置。
+默认监听 8000 端口，可通过环境变量 `PORT` 更改：
+
+```bash
+# macOS / Linux
+PORT=8339 deno task start
+```
+
+```powershell
+# Windows PowerShell
+$env:PORT="8339"
+deno task start
+```
 
 **KV 数据想重置**
 

--- a/main.ts
+++ b/main.ts
@@ -2,9 +2,10 @@
 
 import { CORS_HEADERS } from "./src/constants.ts";
 import { problemResponse } from "./src/http.ts";
-import { cachedConfig } from "./src/state.ts";
+import { cachedConfig, isDenoDeployment } from "./src/state.ts";
 import { isAdminAuthorized } from "./src/auth.ts";
 import { applyKvFlushInterval, bootstrapCache } from "./src/kv.ts";
+import { resolvePort } from "./src/utils.ts";
 
 // Handlers
 import { handleAuthRoutes } from "./src/handlers/auth.ts";
@@ -89,5 +90,10 @@ console.log(`- 存储: Deno KV`);
 if (import.meta.main) {
   await bootstrapCache();
   applyKvFlushInterval(cachedConfig);
-  Deno.serve(handler);
+  if (isDenoDeployment) {
+    Deno.serve(handler);
+  } else {
+    const port = resolvePort(Deno.env.get("PORT"), 8000);
+    Deno.serve({ port }, handler);
+  }
 }

--- a/src/__tests__/utils_test.ts
+++ b/src/__tests__/utils_test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "@std/assert";
+import { resolvePort } from "../utils.ts";
+
+Deno.test("resolvePort - returns fallback for undefined", () => {
+  assertEquals(resolvePort(undefined, 8000), 8000);
+});
+
+Deno.test("resolvePort - returns fallback for empty string", () => {
+  assertEquals(resolvePort("", 8000), 8000);
+  assertEquals(resolvePort("   ", 8000), 8000);
+});
+
+Deno.test("resolvePort - parses valid port", () => {
+  assertEquals(resolvePort("9001", 8000), 9001);
+  assertEquals(resolvePort(" 9001 ", 8000), 9001);
+  assertEquals(resolvePort("00080", 8000), 80);
+});
+
+Deno.test("resolvePort - rejects non-numeric", () => {
+  assertEquals(resolvePort("abc", 8000), 8000);
+  assertEquals(resolvePort("123abc", 8000), 8000);
+  assertEquals(resolvePort("12.3", 8000), 8000);
+  assertEquals(resolvePort("-1", 8000), 8000);
+});
+
+Deno.test("resolvePort - rejects out of range", () => {
+  assertEquals(resolvePort("0", 8000), 8000);
+  assertEquals(resolvePort("65536", 8000), 8000);
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,3 +79,17 @@ export function normalizeKvFlushIntervalMs(ms: number): number {
   if (!Number.isFinite(ms)) return DEFAULT_KV_FLUSH_INTERVAL_MS;
   return Math.max(MIN_KV_FLUSH_INTERVAL_MS, Math.trunc(ms));
 }
+
+export function resolvePort(
+  raw: string | undefined,
+  fallbackPort: number,
+): number {
+  if (!raw) return fallbackPort;
+  const trimmed = raw.trim();
+  if (!trimmed) return fallbackPort;
+  if (!/^\d+$/.test(trimmed)) return fallbackPort;
+  const port = Number(trimmed);
+  if (!Number.isSafeInteger(port)) return fallbackPort;
+  if (port < 1 || port > 65535) return fallbackPort;
+  return port;
+}


### PR DESCRIPTION
Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 增加了通过PORT环境变量配置服务器监听端口的功能，默认端口为8000

* **文档**
  * 更新README、开发和部署文档，说明端口配置方法和使用示例

* **测试**
  * 为端口配置功能添加了单元测试用例

<!-- end of auto-generated comment: release notes by coderabbit.ai -->