### PR TITLE
fix: add exponential backoff to kvUpdateConfig CAS retry

### DIFF
--- a/src/kv.ts
+++ b/src/kv.ts
@@ -251,6 +251,9 @@ export async function kvUpdateConfig(
       setCachedConfig(validatedConfig);
       return validatedConfig;
     }
+    const baseMs = Math.min(10 * 2 ** attempt, 500);
+    const jitter = Math.random() * baseMs;
+    await new Promise((r) => setTimeout(r, baseMs + jitter));
   }
   throw new Error("配置更新失败：达到最大重试次数");
 }


### PR DESCRIPTION
kvUpdateConfig 的 CAS 重试循环现在在失败后等待 exponential backoff + jitter（10ms * 2^attempt，上限 500ms），避免高并发下无退避重试对 KV 的压力。

Closes #73

Co-Authored-By: Warp <agent@warp.dev>