### PR TITLE
fix: validate proxy request body and sanitize error messages

### DIFF
--- a/src/handlers/api-keys.ts
+++ b/src/handlers/api-keys.ts
@@ -129,7 +129,8 @@ export async function handleApiKeyRoutes(
 
       return jsonResponse(result, { status: 201 });
     } catch (error) {
-      return problemResponse(getErrorMessage(error), {
+      console.error("[API-KEYS] add key error:", error);
+      return problemResponse("请求处理失败", {
         status: 400,
         instance: path,
       });
@@ -182,7 +183,8 @@ export async function handleApiKeyRoutes(
         results,
       });
     } catch (error) {
-      return problemResponse(getErrorMessage(error), {
+      console.error("[API-KEYS] batch import error:", error);
+      return problemResponse("请求处理失败", {
         status: 400,
         instance: path,
       });

--- a/src/handlers/auth.ts
+++ b/src/handlers/auth.ts
@@ -1,5 +1,4 @@
 import { jsonResponse, problemResponse } from "../http.ts";
-import { getErrorMessage } from "../utils.ts";
 import {
   createAdminToken,
   deleteAdminToken,
@@ -39,7 +38,8 @@ export async function handleAuthRoutes(
       const token = await createAdminToken();
       return jsonResponse({ success: true, token });
     } catch (error) {
-      return problemResponse(getErrorMessage(error), {
+      console.error("[AUTH] setup error:", error);
+      return problemResponse("请求处理失败", {
         status: 400,
         instance: path,
       });
@@ -56,7 +56,8 @@ export async function handleAuthRoutes(
       const token = await createAdminToken();
       return jsonResponse({ success: true, token });
     } catch (error) {
-      return problemResponse(getErrorMessage(error), {
+      console.error("[AUTH] login error:", error);
+      return problemResponse("请求处理失败", {
         status: 400,
         instance: path,
       });

--- a/src/handlers/config.ts
+++ b/src/handlers/config.ts
@@ -1,7 +1,6 @@
 import { MIN_KV_FLUSH_INTERVAL_MS } from "../constants.ts";
 import { jsonResponse, problemResponse } from "../http.ts";
 import {
-  getErrorMessage,
   maskKey,
   normalizeKvFlushIntervalMs,
 } from "../utils.ts";
@@ -61,7 +60,8 @@ export async function handleConfigRoutes(
         kvFlushIntervalMinMs: MIN_KV_FLUSH_INTERVAL_MS,
       });
     } catch (error) {
-      return problemResponse(getErrorMessage(error), {
+      console.error("[CONFIG] update error:", error);
+      return problemResponse("配置更新失败", {
         status: 400,
         instance: path,
       });

--- a/src/handlers/models.ts
+++ b/src/handlers/models.ts
@@ -148,7 +148,8 @@ export async function handleModelRoutes(
 
       return jsonResponse({ success: true, models });
     } catch (error) {
-      return problemResponse(getErrorMessage(error), {
+      console.error("[MODELS] update pool error:", error);
+      return problemResponse("模型池更新失败", {
         status: 400,
         instance: path,
       });


### PR DESCRIPTION
- **#71**: 代理端点现在校验请求体必须包含非空 messages 数组，无效请求直接 400 不转发
- **#78**: 所有 handler 的 catch 块不再将 error.message 原文返回给客户端，改为通用错误消息 + 服务端日志

Closes #71
Closes #78

Co-Authored-By: Warp <agent@warp.dev>