### PR TITLE
security: add rate limiting to login and setup endpoints

### DIFF
--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,43 @@
+interface BucketEntry {
+  count: number;
+  resetAt: number;
+}
+
+export class RateLimiter {
+  private buckets = new Map<string, BucketEntry>();
+  private readonly maxRequests: number;
+  private readonly windowMs: number;
+
+  constructor(maxRequests: number, windowMs: number) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+  }
+
+  check(key: string): { allowed: boolean; retryAfterMs: number } {
+    const now = Date.now();
+    const entry = this.buckets.get(key);
+
+    if (!entry || now >= entry.resetAt) {
+      this.buckets.set(key, { count: 1, resetAt: now + this.windowMs });
+      return { allowed: true, retryAfterMs: 0 };
+    }
+
+    if (entry.count < this.maxRequests) {
+      entry.count++;
+      return { allowed: true, retryAfterMs: 0 };
+    }
+
+    return { allowed: false, retryAfterMs: entry.resetAt - now };
+  }
+
+  cleanup(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.buckets) {
+      if (now >= entry.resetAt) {
+        this.buckets.delete(key);
+      }
+    }
+  }
+}
+
+export const loginLimiter = new RateLimiter(5, 60_000);


### PR DESCRIPTION
新增 RateLimiter 模块，对 /api/auth/login 和 /api/auth/setup 实施 IP 级别的固定窗口限流（5 次/分钟）。超限返回 429 + Retry-After。

Closes #63

Co-Authored-By: Warp <agent@warp.dev>