### PR TITLE
security: restrict CORS for admin API endpoints

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 // main.ts - Cerebras API 代理与密钥管理系统
 
-import { CORS_HEADERS } from "./src/constants.ts";
+import { ADMIN_CORS_HEADERS, CORS_HEADERS } from "./src/constants.ts";
 import { problemResponse } from "./src/http.ts";
 import { cachedConfig, isDenoDeployment } from "./src/state.ts";
 import { isAdminAuthorized } from "./src/auth.ts";
@@ -29,7 +29,9 @@ async function handler(req: Request): Promise<Response> {
 
   // CORS preflight
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
+    const isProxyPath = path.startsWith("/v1/");
+    const headers = isProxyPath ? CORS_HEADERS : ADMIN_CORS_HEADERS;
+    return new Response(null, { status: 204, headers });
   }
 
   // Auth routes (no login required)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,11 +39,17 @@ export const DEFAULT_MODEL_POOL = [
 export const FALLBACK_MODEL = "qwen-3-235b-a22b-instruct-2507";
 export const EXTERNAL_MODEL_ID = "cerebras-translator";
 
-// HTTP headers
+// HTTP headers — proxy endpoints (open CORS for browser extensions etc.)
 export const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Admin-Token",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+// Admin endpoints — same-origin only (no Access-Control-Allow-Origin)
+export const ADMIN_CORS_HEADERS = {
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
+  "Access-Control-Allow-Headers": "Content-Type, X-Admin-Token",
 };
 
 export const NO_CACHE_HEADERS = {


### PR DESCRIPTION
代理端点（/v1/*）保持 CORS: * 供浏览器扩展调用。管理端点（/api/*）CORS preflight 不再返回 Access-Control-Allow-Origin，强制同源策略。

Closes #70

Co-Authored-By: Warp <agent@warp.dev>