### PR TITLE
feat: add /healthz, bump Deno to 2.6.8, Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM denoland/deno:2.1.0
+FROM denoland/deno:2.6.8
 
 WORKDIR /app
 
-COPY deno.json .
+COPY deno.json deno.lock .
 COPY main.ts .
 COPY src/ ./src/
 
@@ -13,5 +13,8 @@ ENV KV_PATH=/app/data
 RUN deno cache main.ts
 
 EXPOSE 8339
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD deno eval "const r = await fetch('http://localhost:8339/healthz'); if (!r.ok) Deno.exit(1);"
 
 CMD ["run", "--allow-net", "--allow-env", "--allow-read", "--allow-write", "main.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - cerebras-kv:/app/data
     restart: unless-stopped
+    stop_grace_period: 10s
 
 volumes:
   cerebras-kv:

--- a/main.ts
+++ b/main.ts
@@ -76,6 +76,11 @@ async function handler(req: Request): Promise<Response> {
     return await handleProxyEndpoint(req);
   }
 
+  // Health check
+  if (req.method === "GET" && path === "/healthz") {
+    return new Response("ok", { status: 200 });
+  }
+
   // Admin panel
   if (path === "/" && req.method === "GET") {
     return await renderAdminPage();


### PR DESCRIPTION
- **#76**: 添加 GET /healthz 端点，Dockerfile 添加 HEALTHCHECK 指令，docker-compose 添加 stop_grace_period
- **#77**: Deno Docker 镜像从 2.1.0 升级到 2.6.8，同时 COPY deno.lock 保证构建可复现

Closes #76
Closes #77

Co-Authored-By: Warp <agent@warp.dev>