### PR TITLE
refactor: eliminate top-level await in state.ts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2,7 +2,7 @@
 
 import { ADMIN_CORS_HEADERS, CORS_HEADERS } from "./src/constants.ts";
 import { problemResponse } from "./src/http.ts";
-import { cachedConfig, isDenoDeployment } from "./src/state.ts";
+import { cachedConfig, initKv, isDenoDeployment } from "./src/state.ts";
 import { isAdminAuthorized } from "./src/auth.ts";
 import {
   applyKvFlushInterval,
@@ -99,6 +99,7 @@ console.log(`- 模型接口: /v1/models`);
 console.log(`- 存储: Deno KV`);
 
 if (import.meta.main) {
+  await initKv();
   await bootstrapCache();
   applyKvFlushInterval(cachedConfig);
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -26,9 +26,14 @@ function assertKvSupported(): void {
   throw new Error(message);
 }
 
-export const kv = await (() => {
+export let kv: Deno.Kv;
+
+export async function initKv(): Promise<void> {
   assertKvSupported();
-  if (isDenoDeployment) return Deno.openKv();
+  if (isDenoDeployment) {
+    kv = await Deno.openKv();
+    return;
+  }
   const kvDir = Deno.env.get("KV_PATH") ||
     `${import.meta.dirname}/.deno-kv-local`;
   try {
@@ -45,8 +50,8 @@ export const kv = await (() => {
       throw e;
     }
   }
-  return Deno.openKv(`${kvDir}/kv.sqlite3`);
-})();
+  kv = await Deno.openKv(`${kvDir}/kv.sqlite3`);
+}
 
 // Config cache
 export let cachedConfig: ProxyConfig | null = null;


### PR DESCRIPTION
将 state.ts 中的 top-level await KV 初始化改为显式的 initKv() 函数，在 main.ts 的 import.meta.main 块中调用。模块导入不再触发 IO 副作用。

全部 57 个测试通过。

Closes #68

Co-Authored-By: Warp <agent@warp.dev>