### PR TITLE
refactor: replace mutable globals with AppState class singleton (#65)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 import { ADMIN_CORS_HEADERS, CORS_HEADERS } from "./src/constants.ts";
 import { problemResponse } from "./src/http.ts";
-import { cachedConfig, initKv, isDenoDeployment } from "./src/state.ts";
+import { isDenoDeployment, state } from "./src/state.ts";
 import { isAdminAuthorized } from "./src/auth.ts";
 import {
   applyKvFlushInterval,
@@ -62,9 +62,9 @@ console.log(`- 模型接口: /v1/models`);
 console.log(`- 存储: Deno KV`);
 
 if (import.meta.main) {
-  await initKv();
+  await state.initKv();
   await bootstrapCache();
-  applyKvFlushInterval(cachedConfig);
+  applyKvFlushInterval(state.cachedConfig);
 
   if (!isDenoDeployment) {
     const FLUSH_TIMEOUT_MS = 5000;

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -1,54 +1,43 @@
-import {
-  addPendingTotalRequests,
-  cachedActiveKeyIds,
-  cachedConfig,
-  cachedCursor,
-  cachedKeysById,
-  dirtyKeyIds,
-  keyCooldownUntil,
-  setCachedActiveKeyIds,
-  setCachedCursor,
-  setDirtyConfig,
-} from "./state.ts";
+import { state } from "./state.ts";
 
 export function rebuildActiveKeyIds(): void {
-  const keys = Array.from(cachedKeysById.values());
+  const keys = Array.from(state.cachedKeysById.values());
   keys.sort(
     (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
   );
-  setCachedActiveKeyIds(
-    keys.filter((k) => k.status === "active").map((k) => k.id),
+  state.cachedActiveKeyIds = keys.filter((k) => k.status === "active").map(
+    (k) => k.id,
   );
-  if (cachedActiveKeyIds.length === 0) {
-    setCachedCursor(0);
+  if (state.cachedActiveKeyIds.length === 0) {
+    state.cachedCursor = 0;
     return;
   }
-  setCachedCursor(cachedCursor % cachedActiveKeyIds.length);
+  state.cachedCursor = state.cachedCursor % state.cachedActiveKeyIds.length;
 }
 
 export function getNextApiKeyFast(
   now: number,
 ): { key: string; id: string } | null {
-  if (cachedActiveKeyIds.length === 0) return null;
+  if (state.cachedActiveKeyIds.length === 0) return null;
 
-  for (let offset = 0; offset < cachedActiveKeyIds.length; offset++) {
-    const idx = (cachedCursor + offset) % cachedActiveKeyIds.length;
-    const id = cachedActiveKeyIds[idx];
-    const cooldownUntil = keyCooldownUntil.get(id) ?? 0;
+  for (let offset = 0; offset < state.cachedActiveKeyIds.length; offset++) {
+    const idx = (state.cachedCursor + offset) % state.cachedActiveKeyIds.length;
+    const id = state.cachedActiveKeyIds[idx];
+    const cooldownUntil = state.keyCooldownUntil.get(id) ?? 0;
     if (cooldownUntil > now) continue;
 
-    const keyEntry = cachedKeysById.get(id);
+    const keyEntry = state.cachedKeysById.get(id);
     if (!keyEntry || keyEntry.status !== "active") continue;
 
-    setCachedCursor((idx + 1) % cachedActiveKeyIds.length);
+    state.cachedCursor = (idx + 1) % state.cachedActiveKeyIds.length;
 
     keyEntry.useCount += 1;
     keyEntry.lastUsed = now;
-    dirtyKeyIds.add(id);
+    state.dirtyKeyIds.add(id);
 
-    if (cachedConfig) {
-      addPendingTotalRequests(1);
-      setDirtyConfig(true);
+    if (state.cachedConfig) {
+      state.addPendingTotalRequests(1);
+      state.dirtyConfig = true;
     }
 
     return { key: keyEntry.key, id };
@@ -62,15 +51,15 @@ export function markKeyCooldownFrom429(id: string, response: Response): void {
   const retryAfterMs = retryAfter && /^\d+$/.test(retryAfter)
     ? Number.parseInt(retryAfter, 10) * 1000
     : 2000;
-  keyCooldownUntil.set(id, Date.now() + Math.max(0, retryAfterMs));
+  state.keyCooldownUntil.set(id, Date.now() + Math.max(0, retryAfterMs));
 }
 
 export function markKeyInvalid(id: string): void {
-  const keyEntry = cachedKeysById.get(id);
+  const keyEntry = state.cachedKeysById.get(id);
   if (!keyEntry) return;
   if (keyEntry.status === "invalid") return;
   keyEntry.status = "invalid";
-  dirtyKeyIds.add(id);
-  keyCooldownUntil.delete(id);
+  state.dirtyKeyIds.add(id);
+  state.keyCooldownUntil.delete(id);
   rebuildActiveKeyIds();
 }

--- a/src/handlers/api-keys.ts
+++ b/src/handlers/api-keys.ts
@@ -12,7 +12,7 @@ import {
   parseBatchInput,
   safeJsonParse,
 } from "../utils.ts";
-import { cachedModelPool } from "../state.ts";
+import { state } from "../state.ts";
 import {
   kvAddKey,
   kvDeleteKey,
@@ -33,8 +33,8 @@ export async function testKey(
     return { success: false, status: "invalid", error: "密钥不存在" };
   }
 
-  const testModel = cachedModelPool.length > 0
-    ? cachedModelPool[0]
+  const testModel = state.cachedModelPool.length > 0
+    ? state.cachedModelPool[0]
     : FALLBACK_MODEL;
 
   try {

--- a/src/handlers/config.ts
+++ b/src/handlers/config.ts
@@ -4,7 +4,7 @@ import {
   maskKey,
   normalizeKvFlushIntervalMs,
 } from "../utils.ts";
-import { kvFlushIntervalMsEffective } from "../state.ts";
+import { state } from "../state.ts";
 import {
   applyKvFlushInterval,
   kvGetAllKeys,
@@ -53,7 +53,7 @@ async function updateConfig(req: Request): Promise<Response> {
     return jsonResponse({
       success: true,
       kvFlushIntervalMs: normalized,
-      effectiveKvFlushIntervalMs: kvFlushIntervalMsEffective,
+      effectiveKvFlushIntervalMs: state.kvFlushIntervalMsEffective,
       kvFlushIntervalMinMs: MIN_KV_FLUSH_INTERVAL_MS,
     });
   } catch (error) {

--- a/src/handlers/models.ts
+++ b/src/handlers/models.ts
@@ -10,7 +10,7 @@ import {
   isAbortError,
   safeJsonParse,
 } from "../utils.ts";
-import { cachedKeysById, cachedModelCatalog } from "../state.ts";
+import { state } from "../state.ts";
 import {
   isModelCatalogFresh,
   kvGetAllKeys,
@@ -32,7 +32,7 @@ import type { Router } from "../router.ts";
 async function getModelCatalog(): Promise<Response> {
   const now = Date.now();
 
-  let catalog = cachedModelCatalog;
+  let catalog = state.cachedModelCatalog;
   if (!catalog || !isModelCatalogFresh(catalog, now)) {
     const kvCatalog = await kvGetModelCatalog();
     if (kvCatalog) {
@@ -73,7 +73,7 @@ async function getModelCatalog(): Promise<Response> {
 }
 
 async function refreshCatalog(): Promise<Response> {
-  let catalog = cachedModelCatalog ?? (await kvGetModelCatalog());
+  let catalog = state.cachedModelCatalog ?? (await kvGetModelCatalog());
 
   try {
     catalog = await refreshModelCatalog();
@@ -168,7 +168,7 @@ async function testModel(
     });
   }
 
-  let activeKey = Array.from(cachedKeysById.values()).find(
+  let activeKey = Array.from(state.cachedKeysById.values()).find(
     (k) => k.status === "active",
   );
   if (!activeKey) {

--- a/src/handlers/proxy.ts
+++ b/src/handlers/proxy.ts
@@ -12,7 +12,7 @@ import {
   isAbortError,
   safeJsonParse,
 } from "../utils.ts";
-import { cachedActiveKeyIds, keyCooldownUntil } from "../state.ts";
+import { state } from "../state.ts";
 import { isProxyAuthorized, recordProxyKeyUsage } from "../auth.ts";
 import {
   getNextApiKeyFast,
@@ -72,8 +72,8 @@ async function handleProxyEndpoint(req: Request): Promise<Response> {
     }
     if (!apiKeyData) {
       const now = Date.now();
-      const cooldowns = cachedActiveKeyIds
-        .map((id) => keyCooldownUntil.get(id) ?? 0)
+      const cooldowns = state.cachedActiveKeyIds
+        .map((id) => state.keyCooldownUntil.get(id) ?? 0)
         .filter((ms) => ms > now);
       const minCooldownUntil = cooldowns.length > 0
         ? Math.min(...cooldowns)
@@ -84,7 +84,7 @@ async function handleProxyEndpoint(req: Request): Promise<Response> {
 
       return jsonError(
         "没有可用的 API 密钥",
-        cachedActiveKeyIds.length > 0 ? 429 : 500,
+        state.cachedActiveKeyIds.length > 0 ? 429 : 500,
         retryAfterSeconds > 0
           ? { "Retry-After": String(retryAfterSeconds) }
           : undefined,

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,10 +1,4 @@
-import {
-  cachedConfig,
-  cachedModelPool,
-  modelCursor,
-  setCachedModelPool,
-  setModelCursor,
-} from "./state.ts";
+import { state } from "./state.ts";
 
 export function normalizeModelPool(
   rawPool: readonly unknown[] | undefined,
@@ -60,24 +54,24 @@ export function isModelNotFoundPayload(payload: unknown): boolean {
 }
 
 export function getNextModelFast(): string | null {
-  if (cachedModelPool.length === 0) {
+  if (state.cachedModelPool.length === 0) {
     return null;
   }
-  const idx = modelCursor % cachedModelPool.length;
-  const model = cachedModelPool[idx];
-  setModelCursor((idx + 1) % cachedModelPool.length);
+  const idx = state.modelCursor % state.cachedModelPool.length;
+  const model = state.cachedModelPool[idx];
+  state.modelCursor = (idx + 1) % state.cachedModelPool.length;
 
   return model;
 }
 
 export function rebuildModelPoolCache(): void {
-  setCachedModelPool(normalizeModelPool(cachedConfig?.modelPool));
+  state.cachedModelPool = normalizeModelPool(state.cachedConfig?.modelPool);
 
-  if (cachedModelPool.length > 0) {
-    const idx = cachedConfig?.currentModelIndex ?? 0;
-    setModelCursor(idx % cachedModelPool.length);
+  if (state.cachedModelPool.length > 0) {
+    const idx = state.cachedConfig?.currentModelIndex ?? 0;
+    state.modelCursor = idx % state.cachedModelPool.length;
     return;
   }
 
-  setModelCursor(0);
+  state.modelCursor = 0;
 }


### PR DESCRIPTION
Closes #65

## Changes
- New \AppState\ class in \src/state.ts\ encapsulates all mutable runtime state
- Exported singleton \state\ replaces 20+ individual \let\ exports + setter functions
- All 12 consumer files updated: \cachedConfig\ → \state.cachedConfig\, \setCachedConfig(x)\ → \state.cachedConfig = x\
- \initKv()\ becomes \state.initKv()\ method
- \isDenoDeployment\ stays as module-level constant (immutable)
- Net reduction: -111 lines

## Verification
- \deno check\ passes
- \deno lint\ passes (30 files)
- All 57 tests pass

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 重构应用内部状态管理架构，优化代码组织结构。无用户可见功能变更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->