### PR TITLE
Fix coding-discipline reliability gaps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -17,7 +17,8 @@
     "test:coverage": "deno test --allow-net --allow-env --allow-read --allow-write --coverage=coverage",
     "check": "deno check main.ts src",
     "lint": "deno lint main.ts src",
-    "fmt:check": "deno fmt --check main.ts src"
+    "fmt:check": "deno fmt --check main.ts src",
+    "docstring:coverage": "deno run --allow-read scripts/docstring-coverage.mjs --threshold 80"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.18"

--- a/scripts/docstring-coverage.mjs
+++ b/scripts/docstring-coverage.mjs
@@ -1,0 +1,102 @@
+import { parseArgs } from "node:util";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const { values } = parseArgs({
+  options: {
+    root: {
+      type: "string",
+      default:
+        "src/auth.ts,src/handlers/auth.ts,src/kv/flush.ts,src/kv/model-catalog.ts,src/services/api-keys.ts",
+    },
+    threshold: { type: "string", default: "80" },
+  },
+});
+
+const roots = String(values.root).split(",").map((path) => path.trim()).filter(
+  (path) => path.length > 0,
+);
+const threshold = Number(values.threshold);
+if (!Number.isFinite(threshold) || threshold < 0 || threshold > 100) {
+  throw new Error(`Invalid docstring coverage threshold: ${values.threshold}`);
+}
+
+const functionPattern =
+  /(?:^|\n)export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g;
+
+async function collectTsFiles(path) {
+  const stat = await Deno.stat(path);
+  if (stat.isFile) return path.endsWith(".ts") ? [path] : [];
+  if (!stat.isDirectory) return [];
+
+  const entries = await readdir(path, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name === "__tests__" || entry.name === "ui") continue;
+    const childPath = join(path, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectTsFiles(childPath));
+    } else if (entry.isFile() && childPath.endsWith(".ts")) {
+      files.push(childPath);
+    }
+  }
+  return files;
+}
+
+function hasDocComment(source, index) {
+  const declarationStart = source[index] === "\n" ? index + 1 : index;
+  const before = source.slice(0, declarationStart).replace(
+    /(?:^|\n)[^\n]*$/,
+    "",
+  );
+  return /(?:^|\n)[ \t]*(?:(?:\/\*\*[\s\S]*?\*\/)|(?:\/\/\/[^\n]*(?:\n[ \t]*\/\/\/[^\n]*)*))[ \t]*$/
+    .test(
+      before,
+    );
+}
+
+function countMatches(source, pattern, predicate) {
+  let total = 0;
+  let documented = 0;
+  for (const match of source.matchAll(pattern)) {
+    if (predicate !== undefined && !predicate(match)) continue;
+    total += 1;
+    if (hasDocComment(source, match.index)) documented += 1;
+  }
+  return { total, documented };
+}
+
+let total = 0;
+let documented = 0;
+const missing = [];
+
+for (const file of (await Promise.all(roots.map(collectTsFiles))).flat()) {
+  const source = await readFile(file, "utf8");
+  const functions = countMatches(source, functionPattern);
+  total += functions.total;
+  documented += functions.documented;
+
+  for (const match of source.matchAll(functionPattern)) {
+    const name = match[1];
+    if (!hasDocComment(source, match.index)) {
+      const line = source.slice(0, match.index).split("\n").length;
+      missing.push(`${file}:${line} ${name}`);
+    }
+  }
+}
+
+const coverage = total === 0 ? 100 : documented / total * 100;
+console.log(
+  `Docstring coverage: ${coverage.toFixed(2)}% (${documented}/${total})`,
+);
+
+if (coverage < threshold) {
+  console.error(`Required threshold: ${threshold.toFixed(2)}%`);
+  for (const item of missing.slice(0, 50)) {
+    console.error(`missing ${item}`);
+  }
+  if (missing.length > 50) {
+    console.error(`... ${missing.length - 50} more`);
+  }
+  process.exit(1);
+}

--- a/scripts/docstring-coverage.mjs
+++ b/scripts/docstring-coverage.mjs
@@ -1,6 +1,6 @@
 import { parseArgs } from "node:util";
 import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 const { values } = parseArgs({
   options: {
@@ -21,8 +21,11 @@ if (!Number.isFinite(threshold) || threshold < 0 || threshold > 100) {
   throw new Error(`Invalid docstring coverage threshold: ${values.threshold}`);
 }
 
-const functionPattern =
-  /(?:^|\n)export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g;
+const exportedFunctionPatterns = [
+  /(?:^|\n)export\s+(?:default\s+)?(?:async\s+)?function(?:\s*\*)?(?:\s+([A-Za-z_$][\w$]*))?\s*\(/g,
+  /(?:^|\n)export\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:function(?:\s*\*)?(?:\s+[A-Za-z_$][\w$]*)?\s*\(|(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>)/g,
+  /(?:^|\n)export\s+default\s+(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/g,
+];
 
 async function collectTsFiles(path) {
   const stat = await Deno.stat(path);
@@ -55,32 +58,44 @@ function hasDocComment(source, index) {
     );
 }
 
-function countMatches(source, pattern, predicate) {
+function countMatches(source, pattern) {
   let total = 0;
   let documented = 0;
   for (const match of source.matchAll(pattern)) {
-    if (predicate !== undefined && !predicate(match)) continue;
     total += 1;
     if (hasDocComment(source, match.index)) documented += 1;
   }
   return { total, documented };
 }
 
+function missingName(match) {
+  return match[1] ?? "default";
+}
+
 let total = 0;
 let documented = 0;
 const missing = [];
 
-for (const file of (await Promise.all(roots.map(collectTsFiles))).flat()) {
-  const source = await readFile(file, "utf8");
-  const functions = countMatches(source, functionPattern);
-  total += functions.total;
-  documented += functions.documented;
+const files = [
+  ...new Set(
+    (await Promise.all(roots.map(collectTsFiles))).flat().map((file) =>
+      resolve(file)
+    ),
+  ),
+];
 
-  for (const match of source.matchAll(functionPattern)) {
-    const name = match[1];
-    if (!hasDocComment(source, match.index)) {
-      const line = source.slice(0, match.index).split("\n").length;
-      missing.push(`${file}:${line} ${name}`);
+for (const file of files) {
+  const source = await readFile(file, "utf8");
+  for (const pattern of exportedFunctionPatterns) {
+    const functions = countMatches(source, pattern);
+    total += functions.total;
+    documented += functions.documented;
+
+    for (const match of source.matchAll(pattern)) {
+      if (!hasDocComment(source, match.index)) {
+        const line = source.slice(0, match.index).split("\n").length;
+        missing.push(`${file}:${line} ${missingName(match)}`);
+      }
     }
   }
 }

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -1,10 +1,17 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertMatch } from "@std/assert";
 import { AppState, state } from "../state.ts";
 import { createHandler, createRouter } from "../app.ts";
-import { bootstrapCache } from "../kv/flush.ts";
+import { bootstrapCache, flushDirtyToKv } from "../kv/flush.ts";
 import { loginLimiter } from "../rate-limit.ts";
 import { metrics } from "../metrics.ts";
-import { ADMIN_CORS_HEADERS, CORS_HEADERS } from "../constants.ts";
+import {
+  ADMIN_CORS_HEADERS,
+  API_KEY_PREFIX,
+  CORS_HEADERS,
+  DEFAULT_KV_FLUSH_INTERVAL_MS,
+  DEFAULT_MODEL_POOL,
+  PROXY_KEY_PREFIX,
+} from "../constants.ts";
 
 const BASE = "http://localhost";
 
@@ -73,11 +80,12 @@ Deno.test("integration: auth setup → login → logout", async () => {
   assertEquals(setupRes.status, 200);
   const setupBody = await setupRes.json();
   assertEquals(setupBody.success, true);
-  const token = setupBody.token;
+  assertMatch(setupBody.token, /^[0-9a-f-]{36}$/);
+  const setupToken = setupBody.token;
 
   const status2 = await (await handler(
     makeReq("GET", "/api/auth/status", {
-      headers: { "X-Admin-Token": token },
+      headers: { "X-Admin-Token": setupToken },
     }),
   )).json();
   assertEquals(status2.isLoggedIn, true);
@@ -93,6 +101,15 @@ Deno.test("integration: auth setup → login → logout", async () => {
   assertEquals(loginRes.status, 200);
   const loginBody = await loginRes.json();
   assertEquals(loginBody.success, true);
+  assertMatch(loginBody.token, /^[0-9a-f-]{36}$/);
+  const loginToken = loginBody.token;
+
+  const loginStatus = await (await handler(
+    makeReq("GET", "/api/auth/status", {
+      headers: { "X-Admin-Token": loginToken },
+    }),
+  )).json();
+  assertEquals(loginStatus.isLoggedIn, true);
 
   const badLogin = await handler(
     makeReq("POST", "/api/auth/login", { body: { password: "wrong" } }),
@@ -101,15 +118,67 @@ Deno.test("integration: auth setup → login → logout", async () => {
 
   await handler(
     makeReq("POST", "/api/auth/logout", {
-      headers: { "X-Admin-Token": token },
+      headers: { "X-Admin-Token": loginToken },
     }),
   );
   const status3 = await (await handler(
     makeReq("GET", "/api/auth/status", {
-      headers: { "X-Admin-Token": token },
+      headers: { "X-Admin-Token": loginToken },
     }),
   )).json();
   assertEquals(status3.isLoggedIn, false);
+
+  kv.close();
+});
+
+Deno.test("integration: concurrent first-time auth setup creates one admin token", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+
+  const responses = await Promise.all([
+    handler(
+      makeReq("POST", "/api/auth/setup", { body: { password: "first-pass" } }),
+    ),
+    handler(
+      makeReq("POST", "/api/auth/setup", { body: { password: "second-pass" } }),
+    ),
+  ]);
+  const statuses = responses.map((res) => res.status).sort((a, b) => a - b);
+  assertEquals(statuses, [200, 400]);
+
+  const bodies = await Promise.all(responses.map((res) => res.json()));
+  const successBodies = bodies.filter((body) => body.success === true);
+  assertEquals(successBodies.length, 1);
+  assertMatch(successBodies[0].token, /^[0-9a-f-]{36}$/);
+
+  kv.close();
+});
+
+Deno.test("integration: auth rate limit ignores spoofed forwarding headers", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+
+  await handler(
+    makeReq("POST", "/api/auth/setup", { body: { password: "test1234" } }),
+  );
+
+  for (let i = 0; i < 4; i++) {
+    const res = await handler(
+      makeReq("POST", "/api/auth/login", {
+        headers: { "x-forwarded-for": `203.0.113.${i}` },
+        body: { password: "wrong" },
+      }),
+    );
+    assertEquals(res.status, 401);
+  }
+
+  const limited = await handler(
+    makeReq("POST", "/api/auth/login", {
+      headers: { "x-forwarded-for": "203.0.113.99" },
+      body: { password: "wrong" },
+    }),
+  );
+  assertEquals(limited.status, 429);
 
   kv.close();
 });
@@ -190,6 +259,7 @@ Deno.test("integration: proxy key add → list → export → delete", async () 
   assertEquals(addBody.success, true);
   const pkId = addBody.id;
   const rawKey = addBody.key;
+  assertMatch(rawKey, /^cpk_[A-Za-z0-9_-]+$/);
 
   const listRes = await handler(
     makeReq("GET", "/api/proxy-keys", { headers: h }),
@@ -201,6 +271,7 @@ Deno.test("integration: proxy key add → list → export → delete", async () 
   const exportRes = await handler(
     makeReq("GET", `/api/proxy-keys/${pkId}/export`, { headers: h }),
   );
+  assertEquals(exportRes.status, 200);
   const exportBody = await exportRes.json();
   assertEquals(exportBody.key, rawKey);
 
@@ -229,8 +300,8 @@ Deno.test("integration: config get → update", async () => {
   const getRes = await handler(makeReq("GET", "/api/config", { headers: h }));
   assertEquals(getRes.status, 200);
   const getBody = await getRes.json();
-  assertEquals(typeof getBody.kvFlushIntervalMs, "number");
-  assertEquals(typeof getBody.totalRequests, "number");
+  assertEquals(getBody.kvFlushIntervalMs, DEFAULT_KV_FLUSH_INTERVAL_MS);
+  assertEquals(getBody.totalRequests, 0);
 
   const updateRes = await handler(
     makeReq("PATCH", "/api/config", {
@@ -243,10 +314,87 @@ Deno.test("integration: config get → update", async () => {
   assertEquals(updateBody.success, true);
   assertEquals(updateBody.kvFlushIntervalMs, 5000);
 
+  const persistedRes = await handler(
+    makeReq("GET", "/api/config", { headers: h }),
+  );
+  assertEquals(persistedRes.status, 200);
+  const persistedBody = await persistedRes.json();
+  assertEquals(persistedBody.kvFlushIntervalMs, 5000);
+
   if (state.kvFlushTimerId !== null) {
     clearInterval(state.kvFlushTimerId);
     state.kvFlushTimerId = null;
   }
+
+  kv.close();
+});
+
+Deno.test("integration: dirty stats flush does not resurrect deleted API keys", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  const h = { "X-Admin-Token": token };
+
+  const addRes = await handler(
+    makeReq("POST", "/api/keys", {
+      headers: h,
+      body: { key: "sk-race-delete-api" },
+    }),
+  );
+  const { id } = await addRes.json();
+  const cached = state.cachedKeysById.get(id);
+  if (cached === undefined) throw new Error("added API key missing from cache");
+  cached.useCount = 7;
+  cached.lastUsed = 12345;
+  state.dirtyKeyIds.add(id);
+
+  const delRes = await handler(
+    makeReq("DELETE", `/api/keys/${id}`, { headers: h }),
+  );
+  assertEquals(delRes.status, 200);
+  state.cachedKeysById.set(id, cached);
+  state.dirtyKeyIds.add(id);
+
+  await flushDirtyToKv();
+
+  const entry = await state.kv.get([...API_KEY_PREFIX, id]);
+  assertEquals(entry.value, null);
+
+  kv.close();
+});
+
+Deno.test("integration: dirty stats flush does not resurrect deleted proxy keys", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  const h = { "X-Admin-Token": token };
+
+  const addRes = await handler(
+    makeReq("POST", "/api/proxy-keys", {
+      headers: h,
+      body: { name: "race delete" },
+    }),
+  );
+  const { id } = await addRes.json();
+  const cached = state.cachedProxyKeys.get(id);
+  if (cached === undefined) {
+    throw new Error("added proxy key missing from cache");
+  }
+  cached.useCount = 4;
+  cached.lastUsed = 12345;
+  state.dirtyProxyKeyIds.add(id);
+
+  const delRes = await handler(
+    makeReq("DELETE", `/api/proxy-keys/${id}`, { headers: h }),
+  );
+  assertEquals(delRes.status, 200);
+  state.cachedProxyKeys.set(id, cached);
+  state.dirtyProxyKeyIds.add(id);
+
+  await flushDirtyToKv();
+
+  const entry = await state.kv.get([...PROXY_KEY_PREFIX, id]);
+  assertEquals(entry.value, null);
 
   kv.close();
 });
@@ -443,8 +591,7 @@ Deno.test("integration: models GET and PUT", async () => {
   const getRes = await handler(makeReq("GET", "/api/models", { headers: h }));
   assertEquals(getRes.status, 200);
   const getBody = await getRes.json();
-  assertEquals(Array.isArray(getBody.models), true);
-  assertEquals(getBody.models.length > 0, true);
+  assertEquals(getBody.models, DEFAULT_MODEL_POOL);
 
   const putRes = await handler(
     makeReq("PUT", "/api/models", {
@@ -534,11 +681,12 @@ Deno.test("integration: /api/metrics returns counters (requires auth)", async ()
   const handler = buildHandler();
   const token = await setupAuth(handler);
 
-  await handler(
+  const proxyRes = await handler(
     makeReq("POST", "/v1/chat/completions", {
       body: { messages: [{ role: "user", content: "hi" }] },
     }),
   );
+  assertEquals(proxyRes.status, 500);
 
   const res = await handler(
     makeReq("GET", "/api/metrics", {
@@ -547,8 +695,7 @@ Deno.test("integration: /api/metrics returns counters (requires auth)", async ()
   );
   assertEquals(res.status, 200);
   const body = await res.json();
-  assertEquals(typeof body, "object");
-  assertEquals(typeof body.proxy_requests_total, "object");
+  assertEquals(body.proxy_requests_total.no_key, 1);
 
   const noAuth = await handler(makeReq("GET", "/api/metrics"));
   assertEquals(noAuth.status, 401);

--- a/src/__tests__/services_test.ts
+++ b/src/__tests__/services_test.ts
@@ -73,8 +73,28 @@ Deno.test("testKey - does not mark keys active when configured model pool is emp
     status: "error",
     error: "模型池为空",
   });
+  // Empty model configuration must not reclassify the key itself.
   const keyEntry = state.cachedKeysById.get(addResult.id);
   assertEquals(keyEntry?.status, "active");
 
   kv.close();
+});
+
+Deno.test("refreshModelCatalog - rejects null JSON body", async () => {
+  const kv = await setupKv();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () =>
+    Promise.resolve(new Response("null", { status: 200 }));
+
+  try {
+    await assertRejects(
+      () => refreshModelCatalog(),
+      Error,
+      "模型目录响应格式错误",
+    );
+    assertEquals(state.cachedModelCatalog, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
 });

--- a/src/__tests__/services_test.ts
+++ b/src/__tests__/services_test.ts
@@ -1,0 +1,80 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { CEREBRAS_PUBLIC_MODELS_URL } from "../constants.ts";
+import { AppState, state } from "../state.ts";
+import { refreshModelCatalog } from "../kv/model-catalog.ts";
+import { kvAddKey, kvGetApiKeyById } from "../kv/api-keys.ts";
+import { testKey } from "../services/api-keys.ts";
+
+async function setupKv(): Promise<Deno.Kv> {
+  if (state.kvFlushTimerId !== null) {
+    clearInterval(state.kvFlushTimerId);
+  }
+  const kv = await Deno.openKv(":memory:");
+  Object.assign(state, new AppState());
+  state.kv = kv;
+  return kv;
+}
+
+Deno.test("refreshModelCatalog - rejects malformed JSON without caching empty catalog", async () => {
+  const kv = await setupKv();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input: RequestInfo | URL) => {
+    assertEquals(String(input), CEREBRAS_PUBLIC_MODELS_URL);
+    return Promise.resolve(new Response("{not json", { status: 200 }));
+  };
+
+  try {
+    await assertRejects(
+      () => refreshModelCatalog(),
+      Error,
+      "模型目录响应不是有效 JSON",
+    );
+    assertEquals(state.cachedModelCatalog, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
+});
+
+Deno.test("refreshModelCatalog - rejects payloads without data array", async () => {
+  const kv = await setupKv();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () =>
+    Promise.resolve(
+      new Response(JSON.stringify({ models: [{ id: "wrong-shape" }] }), {
+        status: 200,
+      }),
+    );
+
+  try {
+    await assertRejects(
+      () => refreshModelCatalog(),
+      Error,
+      "模型目录响应缺少 data 数组",
+    );
+    assertEquals(state.cachedModelCatalog, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
+});
+
+Deno.test("testKey - does not mark keys active when configured model pool is empty", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-empty-model-pool");
+  if (addResult.id === undefined) throw new Error("API key id missing");
+  await kvGetApiKeyById(addResult.id);
+  state.cachedModelPool = [];
+
+  const result = await testKey(addResult.id);
+
+  assertEquals(result, {
+    success: false,
+    status: "error",
+    error: "模型池为空",
+  });
+  const keyEntry = state.cachedKeysById.get(addResult.id);
+  assertEquals(keyEntry?.status, "active");
+
+  kv.close();
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -13,9 +13,19 @@ export async function getAdminPassword(): Promise<string | null> {
   return entry.value;
 }
 
-export async function setAdminPassword(password: string): Promise<void> {
+export async function setAdminPasswordIfUnset(
+  password: string,
+): Promise<boolean> {
   const hash = await hashPassword(password);
-  await state.kv.set(ADMIN_PASSWORD_KEY, hash);
+  const existing = await state.kv.get<string>(ADMIN_PASSWORD_KEY);
+  if (existing.value !== null) return false;
+
+  const result = await state.kv.atomic()
+    .check(existing)
+    .set(ADMIN_PASSWORD_KEY, hash)
+    .commit();
+
+  return result.ok;
 }
 
 export async function verifyAdminPassword(password: string): Promise<boolean> {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,11 +8,18 @@ import { state } from "./state.ts";
 import { kvGetAllProxyKeys } from "./kv/proxy-keys.ts";
 
 // Admin password management
+/**
+ * Reads the stored admin password hash; null means first-run setup is still available.
+ */
 export async function getAdminPassword(): Promise<string | null> {
   const entry = await state.kv.get<string>(ADMIN_PASSWORD_KEY);
   return entry.value;
 }
 
+/**
+ * Atomically stores the first admin password hash.
+ * Returns false when setup already happened or a concurrent setup won the race.
+ */
 export async function setAdminPasswordIfUnset(
   password: string,
 ): Promise<boolean> {
@@ -28,6 +35,9 @@ export async function setAdminPasswordIfUnset(
   return result.ok;
 }
 
+/**
+ * Verifies a submitted admin password against the stored PBKDF2 hash.
+ */
 export async function verifyAdminPassword(password: string): Promise<boolean> {
   const stored = await getAdminPassword();
   if (!stored) return false;
@@ -35,6 +45,9 @@ export async function verifyAdminPassword(password: string): Promise<boolean> {
 }
 
 // Admin token management
+/**
+ * Creates a short-lived admin session token stored in KV with expiry.
+ */
 export async function createAdminToken(): Promise<string> {
   const token = crypto.randomUUID();
   const expiry = Date.now() + ADMIN_TOKEN_EXPIRY_MS;
@@ -44,6 +57,9 @@ export async function createAdminToken(): Promise<string> {
   return token;
 }
 
+/**
+ * Checks that an admin session token exists and has not expired.
+ */
 export async function verifyAdminToken(token: string | null): Promise<boolean> {
   if (!token) return false;
   const entry = await state.kv.get<number>([...ADMIN_TOKEN_PREFIX, token]);
@@ -55,15 +71,24 @@ export async function verifyAdminToken(token: string | null): Promise<boolean> {
   return true;
 }
 
+/**
+ * Deletes an admin session token; missing tokens are already logged out.
+ */
 export async function deleteAdminToken(token: string): Promise<void> {
   await state.kv.delete([...ADMIN_TOKEN_PREFIX, token]);
 }
 
+/**
+ * Authorizes admin API requests using the X-Admin-Token header.
+ */
 export async function isAdminAuthorized(req: Request): Promise<boolean> {
   const token = req.headers.get("X-Admin-Token");
   return await verifyAdminToken(token);
 }
 
+/**
+ * Finds the cached proxy-key id for an opaque bearer token.
+ */
 function findProxyKeyByToken(token: string): string | null {
   for (const [id, pk] of state.cachedProxyKeys) {
     if (pk.key === token) return id;
@@ -72,6 +97,9 @@ function findProxyKeyByToken(token: string): string | null {
 }
 
 // Proxy authorization
+/**
+ * Authorizes proxy requests, allowing open access until proxy keys exist.
+ */
 export async function isProxyAuthorized(
   req: Request,
 ): Promise<{ authorized: boolean; keyId?: string }> {
@@ -102,6 +130,9 @@ export async function isProxyAuthorized(
   return { authorized: false };
 }
 
+/**
+ * Records deferred usage stats for a proxy key after authorization succeeds.
+ */
 export function recordProxyKeyUsage(keyId: string): void {
   const pk = state.cachedProxyKeys.get(keyId);
   if (!pk) return;

--- a/src/handlers/auth.ts
+++ b/src/handlers/auth.ts
@@ -3,7 +3,7 @@ import {
   createAdminToken,
   deleteAdminToken,
   getAdminPassword,
-  setAdminPassword,
+  setAdminPasswordIfUnset,
   verifyAdminPassword,
   verifyAdminToken,
 } from "../auth.ts";
@@ -11,12 +11,8 @@ import { loginLimiter } from "../rate-limit.ts";
 import { metrics } from "../metrics.ts";
 import type { Router } from "../router.ts";
 
-function getClientIp(req: Request): string {
-  return (
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    req.headers.get("x-real-ip") ||
-    "unknown"
-  );
+function getRateLimitKey(_req: Request): string {
+  return "admin-auth";
 }
 
 async function getAuthStatus(req: Request): Promise<Response> {
@@ -27,8 +23,8 @@ async function getAuthStatus(req: Request): Promise<Response> {
 }
 
 async function setupAuth(req: Request): Promise<Response> {
-  const ip = getClientIp(req);
-  const limit = loginLimiter.check(ip);
+  const key = getRateLimitKey(req);
+  const limit = loginLimiter.check(key);
   if (!limit.allowed) {
     metrics.inc("rate_limit_hits_total", "setup");
     const retryAfter = Math.ceil(limit.retryAfterMs / 1000);
@@ -54,7 +50,13 @@ async function setupAuth(req: Request): Promise<Response> {
         instance: "/api/auth/setup",
       });
     }
-    await setAdminPassword(password);
+    const created = await setAdminPasswordIfUnset(password);
+    if (!created) {
+      return problemResponse("密码已设置", {
+        status: 400,
+        instance: "/api/auth/setup",
+      });
+    }
     const token = await createAdminToken();
     return jsonResponse({ success: true, token });
   } catch (error) {
@@ -67,8 +69,8 @@ async function setupAuth(req: Request): Promise<Response> {
 }
 
 async function loginAuth(req: Request): Promise<Response> {
-  const ip = getClientIp(req);
-  const limit = loginLimiter.check(ip);
+  const key = getRateLimitKey(req);
+  const limit = loginLimiter.check(key);
   if (!limit.allowed) {
     metrics.inc("rate_limit_hits_total", "login");
     const retryAfter = Math.ceil(limit.retryAfterMs / 1000);

--- a/src/handlers/auth.ts
+++ b/src/handlers/auth.ts
@@ -11,10 +11,16 @@ import { loginLimiter } from "../rate-limit.ts";
 import { metrics } from "../metrics.ts";
 import type { Router } from "../router.ts";
 
+/**
+ * Uses one fail-closed auth bucket because forwarded IP headers are not trusted here.
+ */
 function getRateLimitKey(_req: Request): string {
   return "admin-auth";
 }
 
+/**
+ * Reports whether setup is complete and the supplied admin token is valid.
+ */
 async function getAuthStatus(req: Request): Promise<Response> {
   const hasPassword = (await getAdminPassword()) !== null;
   const token = req.headers.get("X-Admin-Token");
@@ -22,6 +28,9 @@ async function getAuthStatus(req: Request): Promise<Response> {
   return jsonResponse({ hasPassword, isLoggedIn });
 }
 
+/**
+ * Handles first-run password setup while preserving the single-admin invariant.
+ */
 async function setupAuth(req: Request): Promise<Response> {
   const key = getRateLimitKey(req);
   const limit = loginLimiter.check(key);
@@ -68,6 +77,9 @@ async function setupAuth(req: Request): Promise<Response> {
   }
 }
 
+/**
+ * Handles admin login under the same non-spoofable bucket as setup.
+ */
 async function loginAuth(req: Request): Promise<Response> {
   const key = getRateLimitKey(req);
   const limit = loginLimiter.check(key);
@@ -101,6 +113,9 @@ async function loginAuth(req: Request): Promise<Response> {
   }
 }
 
+/**
+ * Logs out the current admin token; missing tokens are treated as already logged out.
+ */
 async function logoutAuth(req: Request): Promise<Response> {
   const token = req.headers.get("X-Admin-Token");
   if (token) {
@@ -109,6 +124,9 @@ async function logoutAuth(req: Request): Promise<Response> {
   return jsonResponse({ success: true });
 }
 
+/**
+ * Registers the admin authentication routes on the shared router.
+ */
 export function register(router: Router): void {
   router
     .get("/api/auth/status", getAuthStatus)

--- a/src/kv/flush.ts
+++ b/src/kv/flush.ts
@@ -21,6 +21,9 @@ import { metrics } from "../metrics.ts";
 
 export { resolveKvFlushIntervalMs } from "./config.ts";
 
+/**
+ * Applies the configured KV flush interval by replacing the existing timer.
+ */
 export function applyKvFlushInterval(config: ProxyConfig | null): void {
   state.kvFlushIntervalMsEffective = resolveKvFlushIntervalMs(config);
 
@@ -33,6 +36,10 @@ export function applyKvFlushInterval(config: ProxyConfig | null): void {
   );
 }
 
+/**
+ * Merges cached API-key usage counters without overwriting CRUD changes.
+ * A concurrent delete wins permanently; a concurrent update is retried later.
+ */
 async function flushApiKeyStats(id: string): Promise<void> {
   const keyEntry = state.cachedKeysById.get(id);
   if (!keyEntry) return;
@@ -42,14 +49,30 @@ async function flushApiKeyStats(id: string): Promise<void> {
   const persisted = entry.value;
   if (persisted === null) return;
 
-  await state.kv.set(key, {
-    ...persisted,
-    useCount: Math.max(persisted.useCount, keyEntry.useCount),
-    lastUsed: Math.max(persisted.lastUsed ?? 0, keyEntry.lastUsed ?? 0) ||
-      undefined,
-  });
+  // CAS prevents a stale stats write from recreating or overwriting a key that
+  // changed after the read.
+  const result = await state.kv.atomic()
+    .check(entry)
+    .set(key, {
+      ...persisted,
+      useCount: Math.max(persisted.useCount, keyEntry.useCount),
+      lastUsed: Math.max(persisted.lastUsed ?? 0, keyEntry.lastUsed ?? 0) ||
+        undefined,
+    })
+    .commit();
+
+  if (result.ok) return;
+
+  const latest = await state.kv.get<ApiKey>(key);
+  if (latest.value !== null) {
+    state.dirtyKeyIds.add(id);
+  }
 }
 
+/**
+ * Merges cached proxy-key usage counters without overwriting CRUD changes.
+ * A concurrent delete wins permanently; a concurrent update is retried later.
+ */
 async function flushProxyKeyStats(id: string): Promise<void> {
   const proxyKey = state.cachedProxyKeys.get(id);
   if (!proxyKey) return;
@@ -59,13 +82,26 @@ async function flushProxyKeyStats(id: string): Promise<void> {
   const persisted = entry.value;
   if (persisted === null) return;
 
-  await state.kv.set(key, {
-    ...persisted,
-    useCount: Math.max(persisted.useCount, proxyKey.useCount),
-    lastUsed: Math.max(persisted.lastUsed ?? 0, proxyKey.lastUsed ?? 0) ||
-      undefined,
-  });
+  const result = await state.kv.atomic()
+    .check(entry)
+    .set(key, {
+      ...persisted,
+      useCount: Math.max(persisted.useCount, proxyKey.useCount),
+      lastUsed: Math.max(persisted.lastUsed ?? 0, proxyKey.lastUsed ?? 0) ||
+        undefined,
+    })
+    .commit();
+
+  if (result.ok) return;
+
+  const latest = await state.kv.get<ProxyAuthKey>(key);
+  if (latest.value !== null) {
+    state.dirtyProxyKeyIds.add(id);
+  }
 }
+/**
+ * Flushes batched hot-path counters to KV without overwriting immediate CRUD writes.
+ */
 export async function flushDirtyToKv(): Promise<void> {
   const now = Date.now();
   for (const [id, until] of state.keyCooldownUntil) {
@@ -134,6 +170,9 @@ export async function flushDirtyToKv(): Promise<void> {
   }
 }
 
+/**
+ * Loads persisted config and key records into the hot-path in-memory caches.
+ */
 export async function bootstrapCache(): Promise<void> {
   state.cachedConfig = await kvGetConfig();
   const keys = await kvGetAllKeys();

--- a/src/kv/flush.ts
+++ b/src/kv/flush.ts
@@ -5,7 +5,7 @@
 //   totalRequests. These are batched via a periodic timer to avoid
 //   per-request KV overhead on the proxy critical path.
 
-import type { ProxyConfig } from "../types.ts";
+import type { ApiKey, ProxyAuthKey, ProxyConfig } from "../types.ts";
 import { API_KEY_PREFIX, PROXY_KEY_PREFIX } from "../constants.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
 import { rebuildModelPoolCache } from "../models.ts";
@@ -33,6 +33,39 @@ export function applyKvFlushInterval(config: ProxyConfig | null): void {
   );
 }
 
+async function flushApiKeyStats(id: string): Promise<void> {
+  const keyEntry = state.cachedKeysById.get(id);
+  if (!keyEntry) return;
+
+  const key = [...API_KEY_PREFIX, id];
+  const entry = await state.kv.get<ApiKey>(key);
+  const persisted = entry.value;
+  if (persisted === null) return;
+
+  await state.kv.set(key, {
+    ...persisted,
+    useCount: Math.max(persisted.useCount, keyEntry.useCount),
+    lastUsed: Math.max(persisted.lastUsed ?? 0, keyEntry.lastUsed ?? 0) ||
+      undefined,
+  });
+}
+
+async function flushProxyKeyStats(id: string): Promise<void> {
+  const proxyKey = state.cachedProxyKeys.get(id);
+  if (!proxyKey) return;
+
+  const key = [...PROXY_KEY_PREFIX, id];
+  const entry = await state.kv.get<ProxyAuthKey>(key);
+  const persisted = entry.value;
+  if (persisted === null) return;
+
+  await state.kv.set(key, {
+    ...persisted,
+    useCount: Math.max(persisted.useCount, proxyKey.useCount),
+    lastUsed: Math.max(persisted.lastUsed ?? 0, proxyKey.lastUsed ?? 0) ||
+      undefined,
+  });
+}
 export async function flushDirtyToKv(): Promise<void> {
   const now = Date.now();
   for (const [id, until] of state.keyCooldownUntil) {
@@ -63,14 +96,10 @@ export async function flushDirtyToKv(): Promise<void> {
     try {
       const tasks: Promise<unknown>[] = [];
       for (const id of keyIds) {
-        const keyEntry = state.cachedKeysById.get(id);
-        if (!keyEntry) continue;
-        tasks.push(state.kv.set([...API_KEY_PREFIX, id], keyEntry));
+        tasks.push(flushApiKeyStats(id));
       }
       for (const id of proxyKeyIds) {
-        const pk = state.cachedProxyKeys.get(id);
-        if (!pk) continue;
-        tasks.push(state.kv.set([...PROXY_KEY_PREFIX, id], pk));
+        tasks.push(flushProxyKeyStats(id));
       }
       await Promise.all(tasks);
     } catch (error) {

--- a/src/kv/model-catalog.ts
+++ b/src/kv/model-catalog.ts
@@ -10,6 +10,9 @@ import { normalizeModelPool, rebuildModelPoolCache } from "../models.ts";
 import { state } from "../state.ts";
 import { kvUpdateConfig } from "./config.ts";
 
+/**
+ * Returns whether a model catalog is within the configured cache TTL.
+ */
 export function isModelCatalogFresh(
   catalog: ModelCatalog,
   now: number,
@@ -19,11 +22,17 @@ export function isModelCatalogFresh(
   );
 }
 
+/**
+ * Reads the cached model catalog from KV without refreshing upstream data.
+ */
 export async function kvGetModelCatalog(): Promise<ModelCatalog | null> {
   const entry = await state.kv.get<ModelCatalog>(MODEL_CATALOG_KEY);
   return entry.value ?? null;
 }
 
+/**
+ * Fetches and caches the upstream model catalog only after strict payload validation.
+ */
 export async function refreshModelCatalog(): Promise<ModelCatalog> {
   if (state.modelCatalogFetchInFlight) {
     return await state.modelCatalogFetchInFlight;
@@ -54,6 +63,11 @@ export async function refreshModelCatalog(): Promise<ModelCatalog> {
           error instanceof Error ? error.message : String(error)
         }`,
       );
+    }
+
+    // Guard against valid JSON primitives (null, scalar) before property access.
+    if (typeof data !== "object" || data === null) {
+      throw new Error("模型目录响应格式错误");
     }
 
     const rawModels = (data as { data?: unknown }).data;
@@ -101,6 +115,9 @@ export async function refreshModelCatalog(): Promise<ModelCatalog> {
   return await promise;
 }
 
+/**
+ * Removes an unavailable model from the configured pool and resets rotation.
+ */
 export async function removeModelFromPool(
   model: string,
   reason: string,

--- a/src/kv/model-catalog.ts
+++ b/src/kv/model-catalog.ts
@@ -45,19 +45,30 @@ export async function refreshModelCatalog(): Promise<ModelCatalog> {
       throw new Error(`模型目录拉取失败：HTTP ${response.status}${suffix}`);
     }
 
-    const data = await response.json().catch(() => ({}));
-    const rawModels = (data as { data?: unknown })?.data;
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch (error) {
+      throw new Error(
+        `模型目录响应不是有效 JSON：${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
 
-    const ids = Array.isArray(rawModels)
-      ? rawModels
-        .map((m) => {
-          if (!m || typeof m !== "object") return "";
-          if (!("id" in m)) return "";
-          const id = (m as { id?: unknown }).id;
-          return typeof id === "string" ? id.trim() : "";
-        })
-        .filter((id) => id.length > 0)
-      : [];
+    const rawModels = (data as { data?: unknown }).data;
+    if (!Array.isArray(rawModels)) {
+      throw new Error("模型目录响应缺少 data 数组");
+    }
+
+    const ids = rawModels
+      .map((m) => {
+        if (!m || typeof m !== "object") return "";
+        if (!("id" in m)) return "";
+        const id = (m as { id?: unknown }).id;
+        return typeof id === "string" ? id.trim() : "";
+      })
+      .filter((id) => id.length > 0);
 
     const seen = new Set<string>();
     const models: string[] = [];

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -1,8 +1,4 @@
-import {
-  CEREBRAS_API_URL,
-  FALLBACK_MODEL,
-  UPSTREAM_TEST_TIMEOUT_MS,
-} from "../constants.ts";
+import { CEREBRAS_API_URL, UPSTREAM_TEST_TIMEOUT_MS } from "../constants.ts";
 import {
   fetchWithTimeout,
   getErrorMessage,
@@ -23,9 +19,10 @@ export async function testKey(
     return { success: false, status: "invalid", error: "密钥不存在" };
   }
 
-  const testModel = state.cachedModelPool.length > 0
-    ? state.cachedModelPool[0]
-    : FALLBACK_MODEL;
+  if (state.cachedModelPool.length === 0) {
+    return { success: false, status: "error", error: "模型池为空" };
+  }
+  const testModel = state.cachedModelPool[0];
 
   try {
     const response = await fetchWithTimeout(

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -10,6 +10,9 @@ import { kvGetApiKeyById, kvUpdateKey } from "../kv/api-keys.ts";
 import { removeModelFromPool } from "../kv/model-catalog.ts";
 import { isModelNotFoundPayload, isModelNotFoundText } from "../models.ts";
 
+/**
+ * Tests an API key against the configured model pool; an empty pool is a config error.
+ */
 export async function testKey(
   id: string,
 ): Promise<{ success: boolean; status: string; error?: string }> {


### PR DESCRIPTION
## Summary
- Fix first-time admin setup race with atomic create-if-absent password write.
- Stop trusting spoofable forwarding headers for auth rate-limit buckets.
- Restrict dirty KV flushes to hot-path stats so deleted keys are not resurrected.
- Fail fast on malformed model-catalog payloads instead of caching empty catalogs.
- Stop API-key tests from using a hidden fallback model when the configured pool is empty.
- Strengthen integration assertions for login tokens, config persistence, proxy-key export, default models, and metrics counters.

Closes #97

## Verification
- `npx -y deno test --allow-net --allow-env --allow-read --allow-write` — 81 passed
- `npx -y deno task check`
- `npx -y deno task lint`
- `npx -y deno task fmt:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 管理员认证端点采用固定限流策略并改为仅在未设置时初始化密码，已设置时返回提示
  * 强化模型目录响应校验，严格解析并验证格式
  * 修复持久化刷新逻辑，已删除的 API/代理密钥不会在刷新后被恢复
  * 修改密钥检测：模型池为空时返回明确错误而非使用回退模型

* **Tests / Chores**
  * 增强集成与服务层测试覆盖，新增针对刷新与导出行为的集成断言
  * 添加文档注释覆盖检测任务与脚本 (docstring 覆盖率)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/98)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->