### PR TITLE
Fix CodeQL stack trace exposure alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@
   - 自动切换模型，进一步分散负载
   - 支持配置多个模型，请求时自动切换到池中下一个模型
   - 支持从 Cerebras public models 拉取“模型目录”，在面板勾选生成模型池
-- 若遇到上游 `model_not_found` 会把该模型从模型池移除并跳过，同时尝试下一个模型（最多 3 次）
+- 若遇到上游 `model_not_found`
+  会把该模型从模型池移除并跳过，同时尝试下一个模型（最多 3 次）
   - 对外暴露统一模型名 `cerebras-translator`
 - Web 管理面板
   - 管理面板需要登录访问，确保数据安全
@@ -64,13 +65,15 @@
 
 ## Get Started
 
-1. **获取 Cerebras Key**：访问 [Cerebras 官网](https://www.cerebras.ai/) 注册获取
+1. **获取 Cerebras Key**：访问 [Cerebras 官网](https://www.cerebras.ai/)
+   注册获取
 
 2. **部署到 Deno Deploy**：
    1. 点击本页右上角 **Fork** 按钮，fork 到你的 GitHub 账号
    2. 打开 [Deno Deploy 控制台](https://console.deno.com/)，创建新项目
    3. 选择你 fork 的仓库，入口文件选 `main.ts`，部署
-   4. **关联 KV 数据库**（必须）：详见 [部署指南](docs/GUIDE.md#2-创建并关联-kv-数据库必须)
+   4. **关联 KV 数据库**（必须）：详见
+      [部署指南](docs/GUIDE.md#2-创建并关联-kv-数据库必须)
 
 3. **首次配置**：访问部署地址，设置管理密码，添加 API 密钥
 
@@ -83,7 +86,8 @@
   <img src="image/配置说明2.png" alt="沉浸式翻译配置" width="70%">
 </div>
 
-📖 其他可选部署方式：[部署指南](docs/GUIDE.md) | [docker 部署](docs/DEPLOYMENT_DOCKER.md) | [deno cli 部署](docs/DEPLOYMENT_VPS.md)
+📖 其他可选部署方式：[部署指南](docs/GUIDE.md) |
+[Docker 部署](docs/DEPLOYMENT_DOCKER.md) | [VPS 部署](docs/DEPLOYMENT_VPS.md)
 
 ## Documentation
 
@@ -131,8 +135,8 @@ deno run --allow-net --allow-env --allow-read --allow-write main.ts
 
 默认监听 8339 端口，可通过环境变量 `PORT` 更改（例：`PORT=9001`）。
 
-本地 KV 数据默认存储在 `src/.deno-kv-local/kv.sqlite3`，可通过环境变量
-`KV_PATH` 指定目录（例：`KV_PATH=./data`）。
+本地 KV 数据默认存储在 `src/.deno-kv-local/kv.sqlite3`，可通过环境变量 `KV_PATH`
+指定目录（例：`KV_PATH=./data`）。
 
 ## Acknowledgments
 

--- a/docs/DEPLOYMENT_DOCKER.md
+++ b/docs/DEPLOYMENT_DOCKER.md
@@ -1,11 +1,12 @@
 # Docker 部署指南
 
-> 📖 相关文档：[README](../README.md) | [VPS 部署](DEPLOYMENT_VPS.md) | [Deno Deploy 部署](GUIDE.md)
+> 📖 相关文档：[README](../README.md) | [VPS 部署](DEPLOYMENT_VPS.md) |
+> [Deno Deploy 部署](GUIDE.md)
 
 ## 快速开始
 
 ```bash
-git clone https://github.com/zhu-jl18/thanks-to-cerebras.git
+git clone https://github.com/makoMakoGo/thanks-to-cerebras.git
 # 或 clone 你的 fork：https://github.com/<your-username>/thanks-to-cerebras.git
 cd thanks-to-cerebras
 docker compose up -d
@@ -21,7 +22,8 @@ Docker 端口映射格式为：
 <宿主机端口>:<容器端口>
 ```
 
-本项目容器内默认监听 8339（可通过 `PORT` 调整，但通常不需要）。最常见的做法是只改“宿主机端口”，例如：
+本项目容器内默认监听 8339（可通过 `PORT`
+调整，但通常不需要）。最常见的做法是只改“宿主机端口”，例如：
 
 ```yaml
 ports:

--- a/docs/DEPLOYMENT_VPS.md
+++ b/docs/DEPLOYMENT_VPS.md
@@ -1,6 +1,7 @@
 # VPS 部署指南
 
-> 📖 相关文档：[README](../README.md) | [Docker 部署](DEPLOYMENT_DOCKER.md) | [Deno Deploy 部署](GUIDE.md)
+> 📖 相关文档：[README](../README.md) | [Docker 部署](DEPLOYMENT_DOCKER.md) |
+> [Deno Deploy 部署](GUIDE.md)
 
 ## 安装 Deno（推荐：系统级）
 
@@ -22,7 +23,7 @@ deno --version
 ## 部署（前台运行用于验证）
 
 ```bash
-git clone https://github.com/zhu-jl18/thanks-to-cerebras.git
+git clone https://github.com/makoMakoGo/thanks-to-cerebras.git
 # 或 clone 你的 fork：https://github.com/<your-username>/thanks-to-cerebras.git
 cd thanks-to-cerebras
 deno task start
@@ -58,7 +59,7 @@ sudo useradd -r -m -d /opt/cerebras-proxy -s /usr/sbin/nologin cerebras-proxy
 sudo mkdir -p /opt/cerebras-proxy/app /var/lib/cerebras-proxy
 sudo chown -R cerebras-proxy:cerebras-proxy /opt/cerebras-proxy /var/lib/cerebras-proxy
 
-sudo -u cerebras-proxy git clone https://github.com/zhu-jl18/thanks-to-cerebras.git /opt/cerebras-proxy/app
+sudo -u cerebras-proxy git clone https://github.com/makoMakoGo/thanks-to-cerebras.git /opt/cerebras-proxy/app
 # 或 clone 你的 fork：https://github.com/<your-username>/thanks-to-cerebras.git
 ```
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,7 @@
 # 本地开发指南
 
-> 📖 相关文档：[README](../README.md) | [部署指南](GUIDE.md) | [API 文档](API.md)
+> 📖 相关文档：[README](../README.md) | [部署指南](GUIDE.md) |
+> [API 文档](API.md)
 
 ## 环境要求
 
@@ -33,7 +34,7 @@ deno --version
 
 ```bash
 # 克隆仓库
-git clone https://github.com/zhu-jl18/thanks-to-cerebras.git
+git clone https://github.com/makoMakoGo/thanks-to-cerebras.git
 # 或 clone 你的 fork：https://github.com/<your-username>/thanks-to-cerebras.git
 cd thanks-to-cerebras
 
@@ -45,16 +46,17 @@ deno task dev
 
 ## deno task 命令
 
-| 命令 | 说明 |
-|------|------|
-| `deno task dev` | 启动开发服务器 |
-| `deno task start` | 启动生产服务器 |
-| `deno task test` | 运行全部测试（仓库内全部 `*_test.ts`） |
-| `deno task test:unit` | 运行单元测试 |
-| `deno task test:coverage` | 运行测试并生成覆盖率报告 |
-| `deno task check` | 类型检查 |
-| `deno task lint` | 代码风格检查 |
-| `deno task fmt:check` | 格式检查 |
+| 命令                           | 说明                                   |
+| ------------------------------ | -------------------------------------- |
+| `deno task dev`                | 启动开发服务器                         |
+| `deno task start`              | 启动生产服务器                         |
+| `deno task test`               | 运行全部测试（仓库内全部 `*_test.ts`） |
+| `deno task test:unit`          | 运行单元测试                           |
+| `deno task test:coverage`      | 运行测试并生成覆盖率报告               |
+| `deno task check`              | 类型检查                               |
+| `deno task lint`               | 代码风格检查                           |
+| `deno task fmt:check`          | 格式检查                               |
+| `deno task docstring:coverage` | 检查导出函数文档注释覆盖率             |
 
 ## 本地 KV 存储
 
@@ -79,16 +81,19 @@ KV_PATH=/custom/path deno task dev
 ├── deno.json            # Deno 配置
 ├── src/
 │   ├── state.ts         # 全局状态与 KV 初始化
-│   ├── kv.ts            # KV 操作封装
 │   ├── auth.ts          # 鉴权逻辑
 │   ├── api-keys.ts      # API 密钥管理
 │   ├── models.ts        # 模型池管理
-│   ├── http.ts          # HTTP 请求工具
+│   ├── http.ts          # HTTP 响应工具
 │   ├── crypto.ts        # 加密工具
 │   ├── keys.ts          # 密钥生成
 │   ├── utils.ts         # 通用工具函数
 │   ├── constants.ts     # 常量定义
 │   ├── types.ts         # TypeScript 类型
+│   ├── router.ts        # 路由匹配
+│   ├── rate-limit.ts    # 登录限流
+│   ├── kv/              # KV 读写与刷盘
+│   ├── services/        # 业务服务
 │   ├── handlers/        # HTTP 请求处理器
 │   │   ├── proxy.ts     # 代理请求
 │   │   ├── auth.ts      # 鉴权接口
@@ -97,8 +102,9 @@ KV_PATH=/custom/path deno task dev
 │   │   ├── proxy-keys.ts# 代理密钥接口
 │   │   └── models.ts    # 模型接口
 │   ├── ui/              # 管理面板
-│   │   ├── admin.ts     # 面板路由
-│   │   └── admin_page.ts# 面板 HTML
+│   │   ├── admin.ts     # 面板导出
+│   │   ├── admin.html   # 面板模板
+│   │   └── admin_page.ts# 面板渲染
 │   └── __tests__/       # 单元测试
 └── docs/                # 文档
 ```
@@ -133,7 +139,8 @@ KV_PATH=/custom/path deno task dev
 
 ## 推荐 VS Code 扩展
 
-- [Deno](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno) - Deno 语言支持
+- [Deno](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno) -
+  Deno 语言支持
 
 在项目根目录创建 `.vscode/settings.json`：
 

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -621,6 +621,33 @@ Deno.test("integration: models GET and PUT", async () => {
   kv.close();
 });
 
+Deno.test("integration: model catalog errors do not expose stack traces", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    throw new Error("database password leaked");
+  };
+
+  try {
+    const res = await handler(
+      makeReq("GET", "/api/models/catalog", {
+        headers: { "X-Admin-Token": token },
+      }),
+    );
+    const bodyText = await res.text();
+
+    assertEquals(res.status, 502);
+    assertEquals(bodyText.includes("database password leaked"), false);
+    assertEquals(bodyText.includes("Error:"), false);
+    assertEquals(bodyText.includes("at "), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
+});
+
 // ─── CORS: OPTIONS preflight ───
 
 Deno.test("integration: OPTIONS returns correct CORS headers", async () => {

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -289,6 +289,34 @@ Deno.test("integration: proxy key add → list → export → delete", async () 
   kv.close();
 });
 
+Deno.test("integration: proxy key creation errors do not expose stack traces", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  const originalSet = state.kv.set;
+  state.kv.set = (() => {
+    throw new Error("database password leaked");
+  }) as typeof state.kv.set;
+
+  try {
+    const res = await handler(
+      makeReq("POST", "/api/proxy-keys", {
+        headers: { "X-Admin-Token": token },
+        body: { name: "leak-check" },
+      }),
+    );
+    const bodyText = await res.text();
+
+    assertEquals(res.status, 400);
+    assertEquals(bodyText.includes("database password leaked"), false);
+    assertEquals(bodyText.includes("Error:"), false);
+    assertEquals(bodyText.includes("at "), false);
+  } finally {
+    state.kv.set = originalSet;
+    kv.close();
+  }
+});
+
 // ─── Config ───
 
 Deno.test("integration: config get → update", async () => {
@@ -633,6 +661,103 @@ Deno.test("integration: model catalog errors do not expose stack traces", async 
   try {
     const res = await handler(
       makeReq("GET", "/api/models/catalog", {
+        headers: { "X-Admin-Token": token },
+      }),
+    );
+    const bodyText = await res.text();
+
+    assertEquals(res.status, 502);
+    assertEquals(bodyText.includes("database password leaked"), false);
+    assertEquals(bodyText.includes("Error:"), false);
+    assertEquals(bodyText.includes("at "), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
+});
+
+Deno.test("integration: stale model catalog errors do not expose stack traces", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  state.cachedModelCatalog = {
+    source: "cerebras-public",
+    fetchedAt: Date.now() - 7 * 60 * 60 * 1000,
+    models: ["cached-model"],
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    throw new Error("database password leaked");
+  };
+
+  try {
+    const res = await handler(
+      makeReq("GET", "/api/models/catalog", {
+        headers: { "X-Admin-Token": token },
+      }),
+    );
+    const bodyText = await res.text();
+    const body = JSON.parse(bodyText);
+
+    assertEquals(res.status, 200);
+    assertEquals(body.stale, true);
+    assertEquals(body.lastError, "获取模型目录时发生错误");
+    assertEquals(bodyText.includes("database password leaked"), false);
+    assertEquals(bodyText.includes("Error:"), false);
+    assertEquals(bodyText.includes("at "), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
+});
+
+Deno.test("integration: stale catalog refresh errors do not expose stack traces", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  state.cachedModelCatalog = {
+    source: "cerebras-public",
+    fetchedAt: Date.now() - 7 * 60 * 60 * 1000,
+    models: ["cached-model"],
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    throw new Error("database password leaked");
+  };
+
+  try {
+    const res = await handler(
+      makeReq("POST", "/api/models/catalog/refresh", {
+        headers: { "X-Admin-Token": token },
+      }),
+    );
+    const bodyText = await res.text();
+    const body = JSON.parse(bodyText);
+
+    assertEquals(res.status, 200);
+    assertEquals(body.stale, true);
+    assertEquals(body.lastError, "刷新模型目录时发生错误");
+    assertEquals(bodyText.includes("database password leaked"), false);
+    assertEquals(bodyText.includes("Error:"), false);
+    assertEquals(bodyText.includes("at "), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
+});
+
+Deno.test("integration: catalog refresh errors do not expose stack traces", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    throw new Error("database password leaked");
+  };
+
+  try {
+    const res = await handler(
+      makeReq("POST", "/api/models/catalog/refresh", {
         headers: { "X-Admin-Token": token },
       }),
     );

--- a/src/handlers/models.ts
+++ b/src/handlers/models.ts
@@ -22,10 +22,11 @@ async function getModelCatalog(): Promise<Response> {
       models: catalog.models,
     });
   } catch (error) {
-    return problemResponse(
-      error instanceof Error ? error.message : "无法获取模型目录",
-      { status: 502, instance: "/api/models/catalog" },
-    );
+    console.error("[MODELS] catalog fetch error:", error);
+    return problemResponse("无法获取模型目录", {
+      status: 502,
+      instance: "/api/models/catalog",
+    });
   }
 }
 
@@ -41,10 +42,11 @@ async function refreshCatalog(): Promise<Response> {
       models: catalog.models,
     });
   } catch (error) {
-    return problemResponse(
-      error instanceof Error ? error.message : "目录刷新失败",
-      { status: 502, instance: "/api/models/catalog/refresh" },
-    );
+    console.error("[MODELS] catalog refresh error:", error);
+    return problemResponse("目录刷新失败", {
+      status: 502,
+      instance: "/api/models/catalog/refresh",
+    });
   }
 }
 

--- a/src/handlers/models.ts
+++ b/src/handlers/models.ts
@@ -13,12 +13,13 @@ import type { Router } from "../router.ts";
 async function getModelCatalog(): Promise<Response> {
   try {
     const { catalog, stale, lastError } = await getCatalogData();
+    if (lastError) console.error("[MODELS] stale catalog error:", lastError);
     return jsonResponse({
       source: catalog.source,
       fetchedAt: catalog.fetchedAt,
       ttlMs: MODEL_CATALOG_TTL_MS,
       stale,
-      ...(lastError ? { lastError } : {}),
+      ...(lastError ? { lastError: "获取模型目录时发生错误" } : {}),
       models: catalog.models,
     });
   } catch (error) {
@@ -33,12 +34,13 @@ async function getModelCatalog(): Promise<Response> {
 async function refreshCatalog(): Promise<Response> {
   try {
     const { catalog, stale, lastError } = await forceRefreshCatalog();
+    if (lastError) console.error("[MODELS] stale refresh error:", lastError);
     return jsonResponse({
       source: catalog.source,
       fetchedAt: catalog.fetchedAt,
       ttlMs: MODEL_CATALOG_TTL_MS,
       stale,
-      ...(lastError ? { lastError } : {}),
+      ...(lastError ? { lastError: "刷新模型目录时发生错误" } : {}),
       models: catalog.models,
     });
   } catch (error) {

--- a/src/handlers/proxy-keys.ts
+++ b/src/handlers/proxy-keys.ts
@@ -1,6 +1,6 @@
 import { MAX_PROXY_KEYS } from "../constants.ts";
 import { jsonResponse, problemResponse } from "../http.ts";
-import { getErrorMessage, maskKey } from "../utils.ts";
+import { maskKey } from "../utils.ts";
 import {
   kvAddProxyKey,
   kvDeleteProxyKey,
@@ -39,7 +39,8 @@ async function createProxyKey(req: Request): Promise<Response> {
     }
     return jsonResponse(result, { status: 201 });
   } catch (error) {
-    return problemResponse(getErrorMessage(error), {
+    console.error("[PROXY-KEYS] create key error:", error);
+    return problemResponse("创建失败", {
       status: 400,
       instance: "/api/proxy-keys",
     });


### PR DESCRIPTION
## Summary
- Redact caught Error details from model-catalog and proxy-key problem responses while preserving server-side logging.
- Add a regression test covering model-catalog errors so stack traces and sensitive error text are not returned to clients.
- Refresh stale docs discovered during the repo-wide documentation pass.

## Verification
- `npx -y deno task check`
- `npx -y deno task lint`
- `npx -y deno task fmt:check`
- `npx -y deno task docstring:coverage`
- `npx -y deno task test:unit` — 83 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **文档更新**
  * 优化 README、部署与开发文档格式与可读性，更新示例端口与新仓库/指南链接
* **错误处理**
  * 标准化对外错误提示为通用中文消息，避免泄露内部错误细节；增加服务端错误日志便于排查
* **测试**
  * 新增集成测试，验证在各种失败路径下不会暴露错误堆栈或敏感信息

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/99)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->