### PR TITLE
Fix remaining CodeQL stack trace exposure flows

### DIFF
--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -240,6 +240,44 @@ Deno.test("integration: API key add → list → delete", async () => {
   kv.close();
 });
 
+Deno.test("integration: API key test errors do not expose stack traces", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  const addRes = await handler(
+    makeReq("POST", "/api/keys", {
+      headers: { "X-Admin-Token": token },
+      body: { key: "sk-leak-test" },
+    }),
+  );
+  const { id } = await addRes.json();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    throw new Error("database password leaked");
+  };
+
+  try {
+    const res = await handler(
+      makeReq("POST", `/api/keys/${id}/test`, {
+        headers: { "X-Admin-Token": token },
+      }),
+    );
+    const bodyText = await res.text();
+    const body = JSON.parse(bodyText);
+
+    assertEquals(res.status, 200);
+    assertEquals(body.success, false);
+    assertEquals(body.status, "inactive");
+    assertEquals(body.error, "密钥测试失败");
+    assertEquals(bodyText.includes("database password leaked"), false);
+    assertEquals(bodyText.includes("Error:"), false);
+    assertEquals(bodyText.includes("at "), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
+});
+
 // ─── Proxy Key CRUD ───
 
 Deno.test("integration: proxy key add → list → export → delete", async () => {
@@ -647,6 +685,43 @@ Deno.test("integration: models GET and PUT", async () => {
   assertEquals(badPut.status, 400);
 
   kv.close();
+});
+
+Deno.test("integration: model availability errors do not expose stack traces", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  await handler(
+    makeReq("POST", "/api/keys", {
+      headers: { "X-Admin-Token": token },
+      body: { key: "sk-model-leak-test" },
+    }),
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    throw new Error("database password leaked");
+  };
+
+  try {
+    const res = await handler(
+      makeReq("POST", "/api/models/cached-model/test", {
+        headers: { "X-Admin-Token": token },
+      }),
+    );
+    const bodyText = await res.text();
+    const body = JSON.parse(bodyText);
+
+    assertEquals(res.status, 200);
+    assertEquals(body.success, false);
+    assertEquals(body.status, "error");
+    assertEquals(body.error, "模型测试失败");
+    assertEquals(bodyText.includes("database password leaked"), false);
+    assertEquals(bodyText.includes("Error:"), false);
+    assertEquals(bodyText.includes("at "), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kv.close();
+  }
 });
 
 Deno.test("integration: model catalog errors do not expose stack traces", async () => {

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -78,7 +78,7 @@ export async function testKey(
       error: `HTTP ${response.status}`,
     };
   } catch (error) {
-    console.error("[API-KEYS] test key error:", error);
+    console.error("[API-KEYS] test key error for ID " + id + ":", error);
     await kvUpdateKey(id, { status: "inactive" });
     return {
       success: false,

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -1,10 +1,5 @@
 import { CEREBRAS_API_URL, UPSTREAM_TEST_TIMEOUT_MS } from "../constants.ts";
-import {
-  fetchWithTimeout,
-  getErrorMessage,
-  isAbortError,
-  safeJsonParse,
-} from "../utils.ts";
+import { fetchWithTimeout, isAbortError, safeJsonParse } from "../utils.ts";
 import { state } from "../state.ts";
 import { kvGetApiKeyById, kvUpdateKey } from "../kv/api-keys.ts";
 import { removeModelFromPool } from "../kv/model-catalog.ts";
@@ -83,8 +78,12 @@ export async function testKey(
       error: `HTTP ${response.status}`,
     };
   } catch (error) {
-    const msg = isAbortError(error) ? "请求超时" : getErrorMessage(error);
+    console.error("[API-KEYS] test key error:", error);
     await kvUpdateKey(id, { status: "inactive" });
-    return { success: false, status: "inactive", error: msg };
+    return {
+      success: false,
+      status: "inactive",
+      error: isAbortError(error) ? "请求超时" : "密钥测试失败",
+    };
   }
 }

--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -170,7 +170,7 @@ export async function testModelAvailability(
       error: `HTTP ${response.status}`,
     };
   } catch (error) {
-    console.error("[MODELS] test model error:", error);
+    console.error("[MODELS] test model error for " + modelName + ":", error);
     return {
       success: false,
       status: "error",

--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -170,7 +170,11 @@ export async function testModelAvailability(
       error: `HTTP ${response.status}`,
     };
   } catch (error) {
-    const msg = isAbortError(error) ? "请求超时" : getErrorMessage(error);
-    return { success: false, status: "error", error: msg };
+    console.error("[MODELS] test model error:", error);
+    return {
+      success: false,
+      status: "error",
+      error: isAbortError(error) ? "请求超时" : "模型测试失败",
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Redact raw caught errors returned by the API key and model test endpoints.
- Keep full exception details in server logs.
- Add regression coverage for both remaining CodeQL stack-trace exposure flows.

## Verification
- `npx -y deno test --allow-net --allow-env --allow-read --allow-write src/__tests__/integration_test.ts --filter "do not expose stack traces"` — 7 passed
- `npx -y deno task check`
- `npx -y deno task lint`
- `npx -y deno task fmt:check`
- `npx -y deno task test:unit` — 89 passed
- `npx -y deno task docstring:coverage` — 100.00%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了API错误响应，避免暴露内部错误细节（如堆栈跟踪），并将失败消息标准化为用户友好的中文提示（如 “请求超时”、“密钥测试失败”、“模型测试失败”）。
* **Tests**
  * 为API密钥测试和模型可用性检查端点新增集成测试覆盖，验证错误响应不泄露内部信息。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/100)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->