### PR TITLE
docs: clarify API CORS scope and admin token lifetime

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 ## 0. 约定
 
 - Base URL：`https://<your-project>.deno.dev`
-- 所有接口默认支持 CORS。
+- 对外代理接口（`/v1/*`）支持开放 CORS；管理接口（`/api/*`）仅允许同源访问（不返回 `Access-Control-Allow-Origin`）。
 - `OPTIONS` 预检请求统一返回 `204`。
 - JSON 响应默认带 `Cache-Control: no-store`（用于避免缓存敏感数据/统计）。
 
@@ -20,6 +20,7 @@
 
 - Header：`X-Admin-Token: <token>`
 - token 获取方式见 `/api/auth/login` / `/api/auth/setup`
+- token 有效期默认 7 天（服务端过期后需重新登录）
 
 ### 1.2 代理 API（OpenAI 兼容入口）
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 ## 0. 约定
 
 - Base URL：`https://<your-project>.deno.dev`
-- 对外代理接口（`/v1/*`）支持开放 CORS；管理接口（`/api/*`）仅允许同源访问（不返回 `Access-Control-Allow-Origin`）。
+- 对外代理接口（`/v1/*`）支持开放 CORS（`Access-Control-Allow-Origin: *`）；管理接口（`/api/*`）的 OPTIONS 预检不返回 `Access-Control-Allow-Origin`，浏览器跨域请求会被拦截。
 - `OPTIONS` 预检请求统一返回 `204`。
 - JSON 响应默认带 `Cache-Control: no-store`（用于避免缓存敏感数据/统计）。
 


### PR DESCRIPTION
### Motivation

- The original wording in `docs/API.md` stated that all endpoints support CORS which can mislead integrators about cross-origin access to admin APIs. 
- It was unclear how long admin session tokens remain valid, which may confuse operators when tokens expire.

### Description

- Update `docs/API.md` to state that only proxy endpoints (`/v1/*`) expose open CORS while admin endpoints (`/api/*`) are same-origin and do not return `Access-Control-Allow-Origin`.
- Add a note that admin `X-Admin-Token` tokens have a default expiry of 7 days (service requires re-login after expiry).

### Testing

- This is a documentation-only change to `docs/API.md` and no automated tests were run or required for this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040dcf5b8083338eb005c6325dc7e6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档更新**
  * 调整 API 跨域策略：对外代理接口（/v1/*）允许开放 CORS（Access-Control-Allow-Origin: *），管理接口（/api/*）的预检不再返回该头，浏览器跨域请求将被拦截。
  * 补充管理令牌说明：默认有效期为 7 天，过期后需重新登录。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/101)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->