### PR TITLE
加密存储密钥并禁用明文导出

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@
    4. **关联 KV 数据库**（必须）：详见
       [部署指南](docs/GUIDE.md#2-创建并关联-kv-数据库必须)
 
-3. **首次配置**：在部署环境设置
-   `SETUP_TOKEN`，访问部署地址，输入该初始化令牌后设置管理密码，再添加 API 密钥
+3. **首次配置**：在部署环境设置 `SETUP_TOKEN` 和
+   `KEY_ENCRYPTION_SECRET`，访问部署地址，输入初始化令牌后设置管理密码，再添加
+   API 密钥
 
 4. **配置沉浸式翻译**：
    - 上游地址：`https://<项目名>.deno.dev/v1/chat/completions`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build: .
     ports:
       - "8339:8339"
+    environment:
+      SETUP_TOKEN: ${SETUP_TOKEN}
+      KEY_ENCRYPTION_SECRET: ${KEY_ENCRYPTION_SECRET}
     volumes:
       - cerebras-kv:/app/data
     restart: unless-stopped

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,19 +98,22 @@
 ### 4.1 代理访问密钥（Proxy Keys）
 
 - `GET /api/proxy-keys`
-  - 返回：密钥列表（key 会做
-    mask）、`maxKeys`、`authEnabled`、`proxyPublicAccess`
+  - 返回：密钥元数据列表（不包含明文
+    key）、`maxKeys`、`authEnabled`、`proxyPublicAccess`
 - `POST /api/proxy-keys`
   - 请求体：`{ "name": string }`（可选）
   - 成功：返回新创建的密钥（返回体中会包含一次性明文 key）
 - `DELETE /api/proxy-keys/<id>`
 - `GET /api/proxy-keys/<id>/export`
-  - 返回明文 key（用于复制给客户端）
+  - 返回 `403`；代理密钥只在创建时显示一次
+
+- `POST /api/proxy-keys/migrate`
+  - 将旧 KV 中明文 proxy key 迁移为 HMAC 哈希存储
 
 ### 4.2 Cerebras API 密钥（API Keys）
 
 - `GET /api/keys`
-  - 返回：key 列表（key 会做 mask）
+  - 返回：密钥元数据列表（不包含明文 key）
 - `POST /api/keys`
   - 请求体：`{ "key": string }`
 - `POST /api/keys/batch`
@@ -121,9 +124,11 @@
   - 描述：测活单个 key（会访问上游）
   - 注意：该操作会更新 KV 内该 key 的 `status`
 - `GET /api/keys/export`
-  - 导出全部明文 key
+  - 返回 `403`；明文导出已禁用
 - `GET /api/keys/<id>/export`
-  - 导出单个明文 key
+  - 返回 `403`；明文导出已禁用
+- `POST /api/keys/migrate`
+  - 将旧 KV 中明文 Cerebras API key 迁移为加密存储
 
 ### 4.3 模型池（Models）
 

--- a/docs/DEPLOYMENT_DOCKER.md
+++ b/docs/DEPLOYMENT_DOCKER.md
@@ -14,14 +14,16 @@ docker compose up -d
 
 默认访问 `http://localhost:8339` 进入管理面板。
 
-首次初始化前必须配置 `SETUP_TOKEN`：
+首次初始化前必须配置 `SETUP_TOKEN` 和 `KEY_ENCRYPTION_SECRET`：
 
 ```yaml
 environment:
   - SETUP_TOKEN=<高熵随机字符串>
+  - KEY_ENCRYPTION_SECRET=<高熵随机字符串>
 ```
 
-访问管理面板后输入该令牌并设置管理密码。
+访问管理面板后输入初始化令牌并设置管理密码。`KEY_ENCRYPTION_SECRET` 用于加密
+Cerebras API key 与计算代理密钥 HMAC，丢失后无法解密或校验已存密钥。
 
 ## 端口配置
 

--- a/docs/DEPLOYMENT_VPS.md
+++ b/docs/DEPLOYMENT_VPS.md
@@ -35,10 +35,10 @@ deno task start
 PORT=9001 deno task start
 ```
 
-首次初始化前必须配置 `SETUP_TOKEN`：
+首次初始化前必须配置 `SETUP_TOKEN` 和 `KEY_ENCRYPTION_SECRET`：
 
 ```bash
-SETUP_TOKEN='<高熵随机字符串>' deno task start
+SETUP_TOKEN='<高熵随机字符串>' KEY_ENCRYPTION_SECRET='<高熵随机字符串>' deno task start
 ```
 
 ## KV 数据存储
@@ -85,6 +85,7 @@ WorkingDirectory=/opt/cerebras-proxy/app
 Environment=KV_PATH=/var/lib/cerebras-proxy
 Environment=PORT=8339
 Environment=SETUP_TOKEN=<高熵随机字符串>
+Environment=KEY_ENCRYPTION_SECRET=<高熵随机字符串>
 ExecStart=/usr/local/bin/deno task start
 Restart=always
 RestartSec=5

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -60,8 +60,11 @@ GitHub Fork  ->  Deno Deploy（console）  ->  https://<project>.deno.dev/
 
 ### 3. 设置首次初始化令牌（必须）
 
-在 Deno Deploy 项目的 **Settings → Environment Variables** 中新增
-`SETUP_TOKEN`，值使用高熵随机字符串。该令牌只用于首次创建管理密码，不要写入仓库。
+在 Deno Deploy 项目的 **Settings → Environment Variables** 中新增：
+
+- `SETUP_TOKEN`：高熵随机字符串。该令牌只用于首次创建管理密码，不要写入仓库。
+- `KEY_ENCRYPTION_SECRET`：高熵随机字符串。用于加密 Cerebras API key
+  与计算代理密钥 HMAC，丢失后无法解密或校验已存密钥。
 
 ### 4. 验证部署
 

--- a/docs/TECH_DETAILS.md
+++ b/docs/TECH_DETAILS.md
@@ -16,20 +16,27 @@ Client -> /v1/chat/completions -> Deno Proxy -> Cerebras API
 2. **代理访问密钥** - 控制谁能调用代理 API（最多 5 个）
 3. **Cerebras API 密钥** - 调用上游 Cerebras API
 
+## 密钥存储
+
+`KEY_ENCRYPTION_SECRET` 是密钥存储主密钥：
+
+- Cerebras API key 使用 AES-GCM 加密后写入
+  KV，热路径只在内存缓存中保存解密后的值。
+- 代理访问密钥只在创建响应中返回一次，KV 中只保存 HMAC-SHA-256 哈希。
+- 明文导出接口返回 `403`。旧明文 KV 记录必须通过管理 API 迁移后才能继续使用。
+
 ## 鉴权逻辑
 
 代理访问密钥存储在 KV，默认拒绝未授权访问。只有显式开启公开访问时，才允许无
 Bearer token 调用代理。
 
 ```typescript
-function isProxyAuthorized(req: Request) {
+async function isProxyAuthorized(req: Request) {
   if (cachedConfig.proxyPublicAccess) return { authorized: true };
 
   const token = req.headers.get("Authorization")?.substring(7);
-  for (const pk of cachedProxyKeys.values()) {
-    if (pk.key === token) return { authorized: true, keyId: pk.id };
-  }
-  return { authorized: false };
+  const keyId = await findProxyKeyIdBySecret(token);
+  return keyId ? { authorized: true, keyId } : { authorized: false };
 }
 ```
 
@@ -86,12 +93,12 @@ isolate、冷启动和多区域部署不会各自拥有独立内存窗口。
 
 // Cerebras API 密钥
 [KV_PREFIX, "keys", "api", <id>] -> ApiKey {
-  id, key, useCount, lastUsed, status, createdAt
+  id, encryptedKey, useCount, lastUsed, status, createdAt
 }
 
 // 代理访问密钥
 [KV_PREFIX, "keys", "proxy", <id>] -> ProxyAuthKey {
-  id, key, name, useCount, lastUsed, createdAt
+  id, keyHash, name, useCount, lastUsed, createdAt
 }
 
 // 限流桶

--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import {
 } from "./src/kv/flush.ts";
 import { resolvePort } from "./src/utils.ts";
 import { createHandler, createRouter } from "./src/app.ts";
+import { assertKeyEncryptionSecretConfigured } from "./src/secrets.ts";
 
 if (import.meta.main) {
   const router = createRouter();
@@ -19,6 +20,8 @@ if (import.meta.main) {
   console.log(`- API 代理: /v1/chat/completions`);
   console.log(`- 模型接口: /v1/models`);
   console.log(`- 存储: Deno KV`);
+
+  assertKeyEncryptionSecretConfigured();
 
   await state.initKv();
   await bootstrapCache();

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -25,6 +25,7 @@ import {
   PROXY_UNAUTHORIZED_RATE_LIMIT_MAX,
 } from "../constants.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
+import { encryptApiKey } from "../secrets.ts";
 const BASE = "http://localhost";
 
 type Handler = (req: Request) => Promise<Response>;
@@ -59,6 +60,7 @@ async function setupKv(): Promise<Deno.Kv> {
   }
   const kv = await Deno.openKv(":memory:");
   Deno.env.set("SETUP_TOKEN", "test-setup-token");
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
   Object.assign(state, new AppState());
   state.kv = kv;
   await bootstrapCache();
@@ -97,17 +99,25 @@ async function addActiveApiKey(key: string): Promise<void> {
   const apiKey = {
     id: crypto.randomUUID(),
     key,
+    encryptedKey: await encryptApiKey(key),
     useCount: 0,
     status: "active" as const,
     createdAt: Date.now(),
   };
-  await state.kv.set([...API_KEY_PREFIX, apiKey.id], apiKey);
+  await state.kv.set([...API_KEY_PREFIX, apiKey.id], {
+    id: apiKey.id,
+    encryptedKey: apiKey.encryptedKey,
+    useCount: apiKey.useCount,
+    status: apiKey.status,
+    createdAt: apiKey.createdAt,
+  });
   state.cachedKeysById.set(apiKey.id, apiKey);
   rebuildActiveKeyIds();
 }
 
 function installUpstreamResponse(
   response: Response | (() => Response),
+  expectedAuthorization = "Bearer sk-upstream-test",
 ): () => void {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
@@ -115,7 +125,7 @@ function installUpstreamResponse(
       throw new Error(`unexpected fetch input ${String(input)}`);
     }
     const authorization = new Headers(init?.headers).get("Authorization");
-    if (authorization !== "Bearer sk-upstream-test") {
+    if (authorization !== expectedAuthorization) {
       throw new Error("unexpected upstream authorization header");
     }
     return Promise.resolve(
@@ -441,7 +451,25 @@ Deno.test("integration: API key add → list → delete", async () => {
   const listBody = await listRes.json();
   assertEquals(listBody.keys.length, 1);
   assertEquals(listBody.keys[0].id, keyId);
+  assertEquals(listBody.keys[0].key, undefined);
 
+  const storedApiKey = await kv.get([...API_KEY_PREFIX, keyId]);
+  assertEquals((storedApiKey.value as { key?: string }).key, undefined);
+  assertEquals(
+    typeof (storedApiKey.value as { encryptedKey?: string }).encryptedKey,
+    "string",
+  );
+  assertEquals(
+    (storedApiKey.value as { encryptedKey: string }).encryptedKey.includes(
+      "sk-test-abc123",
+    ),
+    false,
+  );
+
+  const exportRes = await handler(
+    makeReq("GET", `/api/keys/${keyId}/export`, { headers: h }),
+  );
+  assertEquals(exportRes.status, 403);
   const delRes = await handler(
     makeReq("DELETE", `/api/keys/${keyId}`, { headers: h }),
   );
@@ -494,7 +522,7 @@ Deno.test("integration: API key test errors do not expose stack traces", async (
 
 // ─── Proxy Key CRUD ───
 
-Deno.test("integration: proxy key add → list → export → delete", async () => {
+Deno.test("integration: proxy key add → list → delete", async () => {
   const kv = await setupKv();
   const handler = buildHandler();
   const token = await setupAuth(handler);
@@ -519,13 +547,23 @@ Deno.test("integration: proxy key add → list → export → delete", async () 
   const listBody = await listRes.json();
   assertEquals(listBody.keys.length, 1);
   assertEquals(listBody.keys[0].name, "Test Key");
+  assertEquals(listBody.keys[0].key, undefined);
+
+  const storedProxyKey = await kv.get([...PROXY_KEY_PREFIX, pkId]);
+  assertEquals((storedProxyKey.value as { key?: string }).key, undefined);
+  assertEquals(
+    typeof (storedProxyKey.value as { keyHash?: string }).keyHash,
+    "string",
+  );
+  assertEquals(
+    (storedProxyKey.value as { keyHash: string }).keyHash.includes(rawKey),
+    false,
+  );
 
   const exportRes = await handler(
     makeReq("GET", `/api/proxy-keys/${pkId}/export`, { headers: h }),
   );
-  assertEquals(exportRes.status, 200);
-  const exportBody = await exportRes.json();
-  assertEquals(exportBody.key, rawKey);
+  assertEquals(exportRes.status, 403);
 
   const delRes = await handler(
     makeReq("DELETE", `/api/proxy-keys/${pkId}`, { headers: h }),
@@ -565,6 +603,72 @@ Deno.test("integration: proxy key list errors are structured", async () => {
     );
   } finally {
     state.kv.list = originalList;
+    kv.close();
+  }
+});
+
+Deno.test("integration: legacy stored keys migrate to encrypted records", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+  const h = { "X-Admin-Token": token };
+  const apiKeyId = crypto.randomUUID();
+  const proxyKeyId = crypto.randomUUID();
+
+  await kv.set([...API_KEY_PREFIX, apiKeyId], {
+    id: apiKeyId,
+    key: "sk-legacy-api",
+    useCount: 0,
+    status: "active",
+    createdAt: 1,
+  });
+  await kv.set([...PROXY_KEY_PREFIX, proxyKeyId], {
+    id: proxyKeyId,
+    key: "cpk_legacy_proxy",
+    name: "legacy",
+    useCount: 0,
+    createdAt: 1,
+  });
+
+  const apiMigrate = await handler(
+    makeReq("POST", "/api/keys/migrate", { headers: h }),
+  );
+  assertEquals(apiMigrate.status, 200);
+  assertEquals((await apiMigrate.json()).migrated, 1);
+  const proxyMigrate = await handler(
+    makeReq("POST", "/api/proxy-keys/migrate", { headers: h }),
+  );
+  assertEquals(proxyMigrate.status, 200);
+  assertEquals((await proxyMigrate.json()).migrated, 1);
+
+  const migratedApiKey = await kv.get([...API_KEY_PREFIX, apiKeyId]);
+  assertEquals((migratedApiKey.value as { key?: string }).key, undefined);
+  assertEquals(
+    typeof (migratedApiKey.value as { encryptedKey?: string }).encryptedKey,
+    "string",
+  );
+  const migratedProxyKey = await kv.get([...PROXY_KEY_PREFIX, proxyKeyId]);
+  assertEquals((migratedProxyKey.value as { key?: string }).key, undefined);
+  assertEquals(
+    typeof (migratedProxyKey.value as { keyHash?: string }).keyHash,
+    "string",
+  );
+
+  const restoreFetch = installUpstreamResponse(
+    new Response("ok", { status: 200 }),
+    "Bearer sk-legacy-api",
+  );
+  try {
+    const res = await handler(
+      makeReq("POST", "/v1/chat/completions", {
+        headers: { Authorization: "Bearer cpk_legacy_proxy" },
+        body: { messages: [{ role: "user", content: "hi" }] },
+      }),
+    );
+    assertEquals(res.status, 200);
+    await res.body?.cancel();
+  } finally {
+    restoreFetch();
     kv.close();
   }
 });

--- a/src/__tests__/secrets_test.ts
+++ b/src/__tests__/secrets_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import {
+  assertKeyEncryptionSecretConfigured,
+  decryptApiKey,
+  encryptApiKey,
+  hashProxyKey,
+  isEncryptedApiKey,
+  isHashedProxyKey,
+  verifyProxyKey,
+} from "../secrets.ts";
+
+Deno.test("secrets - encrypts API keys without storing plaintext", async () => {
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "unit-secret");
+
+  const encrypted = await encryptApiKey("sk-unit-secret");
+
+  assertEquals(isEncryptedApiKey(encrypted), true);
+  assertEquals(encrypted.includes("sk-unit-secret"), false);
+  assertEquals(await decryptApiKey(encrypted), "sk-unit-secret");
+});
+
+Deno.test("secrets - fails fast when encryption secret is missing", async () => {
+  Deno.env.delete("KEY_ENCRYPTION_SECRET");
+
+  await assertRejects(
+    () => encryptApiKey("sk-unit-secret"),
+    Error,
+    "KEY_ENCRYPTION_SECRET 未配置",
+  );
+});
+
+Deno.test("secrets - validates startup encryption secret", () => {
+  Deno.env.delete("KEY_ENCRYPTION_SECRET");
+
+  assertThrows(
+    () => assertKeyEncryptionSecretConfigured(),
+    Error,
+    "KEY_ENCRYPTION_SECRET 未配置",
+  );
+});
+
+Deno.test("secrets - hashes proxy keys for verification", async () => {
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "unit-secret");
+
+  const hash = await hashProxyKey("cpk_unit_secret");
+
+  assertEquals(isHashedProxyKey(hash), true);
+  assertEquals(hash.includes("cpk_unit_secret"), false);
+  assertEquals(await verifyProxyKey("cpk_unit_secret", hash), true);
+  assertEquals(await verifyProxyKey("cpk_wrong", hash), false);
+});

--- a/src/__tests__/services_test.ts
+++ b/src/__tests__/services_test.ts
@@ -10,6 +10,7 @@ async function setupKv(): Promise<Deno.Kv> {
     clearInterval(state.kvFlushTimerId);
   }
   const kv = await Deno.openKv(":memory:");
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
   Object.assign(state, new AppState());
   state.kv = kv;
   return kv;

--- a/src/__tests__/stream-limits_test.ts
+++ b/src/__tests__/stream-limits_test.ts
@@ -8,6 +8,7 @@ import {
 
 async function setupKv(): Promise<Deno.Kv> {
   const kv = await Deno.openKv(":memory:");
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
   Object.assign(state, new AppState());
   state.kv = kv;
   await resetProxyStreamCountersForTests();

--- a/src/__tests__/test_utils.ts
+++ b/src/__tests__/test_utils.ts
@@ -11,6 +11,7 @@ export function createMockApiKey(overrides: Partial<ApiKey> = {}): ApiKey {
   return {
     id: crypto.randomUUID(),
     key: `test-key-${Date.now()}`,
+    encryptedKey: "v1$aes-gcm$test$test",
     useCount: 0,
     status: "active",
     createdAt: Date.now(),
@@ -26,7 +27,7 @@ export function createMockProxyKey(
 ): ProxyAuthKey {
   return {
     id: crypto.randomUUID(),
-    key: `pk-test-${Date.now()}`,
+    keyHash: "v1$hmac-sha256$test",
     name: "Test Proxy Key",
     useCount: 0,
     createdAt: Date.now(),

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -29,6 +29,9 @@ export function getNextApiKeyFast(
 
     const keyEntry = state.cachedKeysById.get(id);
     if (!keyEntry || keyEntry.status !== "active") continue;
+    if (!keyEntry.key) {
+      throw new Error(`API key ${id} 未解密`);
+    }
 
     state.cachedCursor = (idx + 1) % state.cachedActiveKeyIds.length;
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,7 +6,7 @@ import {
 } from "./constants.ts";
 import { hashPassword, verifyPbkdf2Password } from "./crypto.ts";
 import { state } from "./state.ts";
-import { kvGetAllProxyKeys } from "./kv/proxy-keys.ts";
+import { findProxyKeyIdBySecret, kvGetAllProxyKeys } from "./kv/proxy-keys.ts";
 import type { ProxyAuthKey } from "./types.ts";
 
 // Admin password management
@@ -91,14 +91,8 @@ export async function isAdminAuthorized(req: Request): Promise<boolean> {
 /**
  * Finds the cached proxy-key id for an opaque bearer token.
  */
-function findProxyKeyByToken(
-  keys: Map<string, ProxyAuthKey>,
-  token: string,
-): string | null {
-  for (const [id, pk] of keys) {
-    if (pk.key === token) return id;
-  }
-  return null;
+async function findProxyKeyByToken(token: string): Promise<string | null> {
+  return await findProxyKeyIdBySecret(token);
 }
 
 async function loadProxyKeyCache(): Promise<Map<string, ProxyAuthKey>> {
@@ -152,12 +146,12 @@ export async function isProxyAuthorized(
 
   const token = authHeader.substring(7).trim();
 
-  const match = findProxyKeyByToken(keys, token);
+  const match = await findProxyKeyByToken(token);
   if (match) return { authorized: true, keyId: match };
 
   if (shouldRefreshProxyKeyCache()) {
-    keys = await refreshProxyKeyCache();
-    const retryMatch = findProxyKeyByToken(keys, token);
+    await refreshProxyKeyCache();
+    const retryMatch = await findProxyKeyByToken(token);
     if (retryMatch) return { authorized: true, keyId: retryMatch };
   }
 

--- a/src/handlers/api-keys.ts
+++ b/src/handlers/api-keys.ts
@@ -4,7 +4,7 @@ import {
   kvAddKey,
   kvDeleteKey,
   kvGetAllKeys,
-  kvGetApiKeyById,
+  kvMigrateApiKeysToEncrypted,
 } from "../kv/api-keys.ts";
 import { testKey } from "../services/api-keys.ts";
 import type { Router } from "../router.ts";
@@ -12,11 +12,14 @@ import type { Router } from "../router.ts";
 async function listApiKeys(): Promise<Response> {
   const keys = await kvGetAllKeys();
   keys.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
-  const maskedKeys = keys.map((k) => ({
-    ...k,
-    key: maskKey(k.key),
+  const keyMetadata = keys.map((k) => ({
+    id: k.id,
+    useCount: k.useCount,
+    lastUsed: k.lastUsed,
+    status: k.status,
+    createdAt: k.createdAt,
   }));
-  return adminJsonResponse({ keys: maskedKeys });
+  return adminJsonResponse({ keys: keyMetadata });
 }
 
 async function addApiKey(req: Request): Promise<Response> {
@@ -101,25 +104,21 @@ async function batchImportApiKeys(req: Request): Promise<Response> {
   }
 }
 
-async function exportAllApiKeys(): Promise<Response> {
-  const keys = await kvGetAllKeys();
-  keys.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
-  const rawKeys = keys.map((k) => k.key);
-  return adminJsonResponse({ keys: rawKeys });
+function exportAllApiKeys(): Response {
+  return adminProblemResponse("密钥明文导出已禁用", {
+    status: 403,
+    instance: "/api/keys/export",
+  });
 }
 
-async function exportApiKey(
+function exportApiKey(
   _req: Request,
   params: Record<string, string>,
-): Promise<Response> {
-  const keyEntry = await kvGetApiKeyById(params.id);
-  if (!keyEntry) {
-    return adminProblemResponse("密钥不存在", {
-      status: 404,
-      instance: `/api/keys/${params.id}/export`,
-    });
-  }
-  return adminJsonResponse({ key: keyEntry.key });
+): Response {
+  return adminProblemResponse("密钥明文导出已禁用", {
+    status: 403,
+    instance: `/api/keys/${params.id}/export`,
+  });
 }
 
 async function deleteApiKey(
@@ -143,11 +142,17 @@ async function testApiKey(
   return adminJsonResponse(await testKey(params.id));
 }
 
+async function migrateApiKeys(): Promise<Response> {
+  const migrated = await kvMigrateApiKeysToEncrypted();
+  return adminJsonResponse({ success: true, migrated });
+}
+
 export function register(router: Router): void {
   router
     .get("/api/keys", listApiKeys)
     .post("/api/keys", addApiKey)
     .post("/api/keys/batch", batchImportApiKeys)
+    .post("/api/keys/migrate", migrateApiKeys)
     .get("/api/keys/export", exportAllApiKeys)
     .get("/api/keys/:id/export", exportApiKey)
     .delete("/api/keys/:id", deleteApiKey)

--- a/src/handlers/config.ts
+++ b/src/handlers/config.ts
@@ -1,6 +1,6 @@
 import { MIN_KV_FLUSH_INTERVAL_MS } from "../constants.ts";
 import { adminJsonResponse, adminProblemResponse } from "../http.ts";
-import { maskKey, normalizeKvFlushIntervalMs } from "../utils.ts";
+import { normalizeKvFlushIntervalMs } from "../utils.ts";
 import { state } from "../state.ts";
 import { kvGetAllKeys } from "../kv/api-keys.ts";
 import {
@@ -19,7 +19,6 @@ async function getStats(): Promise<Response> {
     totalRequests: config.totalRequests,
     keyUsage: keys.map((k) => ({
       id: k.id,
-      maskedKey: maskKey(k.key),
       useCount: k.useCount,
       status: k.status,
     })),

--- a/src/handlers/proxy-keys.ts
+++ b/src/handlers/proxy-keys.ts
@@ -1,11 +1,10 @@
 import { MAX_PROXY_KEYS } from "../constants.ts";
 import { adminJsonResponse, adminProblemResponse } from "../http.ts";
-import { maskKey } from "../utils.ts";
 import {
   kvAddProxyKey,
   kvDeleteProxyKey,
   kvGetAllProxyKeys,
-  kvGetProxyKeyById,
+  kvMigrateProxyKeysToHashed,
 } from "../kv/proxy-keys.ts";
 import { kvGetConfig } from "../kv/config.ts";
 import type { Router } from "../router.ts";
@@ -17,16 +16,15 @@ async function listProxyKeys(): Promise<Response> {
       kvGetConfig(),
     ]);
     keys.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
-    const masked = keys.map((k) => ({
+    const keyMetadata = keys.map((k) => ({
       id: k.id,
-      key: maskKey(k.key),
       name: k.name,
       useCount: k.useCount,
       lastUsed: k.lastUsed,
       createdAt: k.createdAt,
     }));
     return adminJsonResponse({
-      keys: masked,
+      keys: keyMetadata,
       maxKeys: MAX_PROXY_KEYS,
       authEnabled: true,
       proxyPublicAccess: config.proxyPublicAccess,
@@ -74,24 +72,26 @@ async function deleteProxyKey(
   return adminJsonResponse(result);
 }
 
-async function exportProxyKey(
+function exportProxyKey(
   _req: Request,
   params: Record<string, string>,
-): Promise<Response> {
-  const pk = await kvGetProxyKeyById(params.id);
-  if (!pk) {
-    return adminProblemResponse("密钥不存在", {
-      status: 404,
-      instance: `/api/proxy-keys/${params.id}/export`,
-    });
-  }
-  return adminJsonResponse({ key: pk.key });
+): Response {
+  return adminProblemResponse("代理密钥只在创建时显示一次", {
+    status: 403,
+    instance: `/api/proxy-keys/${params.id}/export`,
+  });
+}
+
+async function migrateProxyKeys(): Promise<Response> {
+  const migrated = await kvMigrateProxyKeysToHashed();
+  return adminJsonResponse({ success: true, migrated });
 }
 
 export function register(router: Router): void {
   router
     .get("/api/proxy-keys", listProxyKeys)
     .post("/api/proxy-keys", createProxyKey)
+    .post("/api/proxy-keys/migrate", migrateProxyKeys)
     .delete("/api/proxy-keys/:id", deleteProxyKey)
     .get("/api/proxy-keys/:id/export", exportProxyKey);
 }

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -2,13 +2,42 @@ import type { ApiKey } from "../types.ts";
 import { API_KEY_PREFIX } from "../constants.ts";
 import { generateId } from "../utils.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
+import { decryptApiKey, encryptApiKey, isEncryptedApiKey } from "../secrets.ts";
 import { state } from "../state.ts";
+
+type PersistedApiKey = Omit<ApiKey, "key">;
+
+type LegacyApiKey = Omit<ApiKey, "encryptedKey"> & { key: string };
+
+function assertCurrentApiKey(value: unknown): PersistedApiKey {
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.encryptedKey !== "string") {
+    throw new Error("API key 存储格式不兼容：需要先运行密钥迁移");
+  }
+  if (!isEncryptedApiKey(raw.encryptedKey)) {
+    throw new Error("API key 密文格式错误");
+  }
+  return raw as unknown as PersistedApiKey;
+}
+
+async function hydrateApiKey(value: unknown): Promise<ApiKey> {
+  const persisted = assertCurrentApiKey(value);
+  return {
+    ...persisted,
+    key: await decryptApiKey(persisted.encryptedKey),
+  };
+}
+
+function toPersistedApiKey(key: ApiKey): PersistedApiKey {
+  const { key: _plaintext, ...persisted } = key;
+  return persisted;
+}
 
 export async function kvGetAllKeys(): Promise<ApiKey[]> {
   const keys: ApiKey[] = [];
   const iter = state.kv.list({ prefix: API_KEY_PREFIX });
   for await (const entry of iter) {
-    keys.push(entry.value as ApiKey);
+    keys.push(await hydrateApiKey(entry.value));
   }
   return keys;
 }
@@ -29,6 +58,7 @@ export async function kvMergeAllApiKeysIntoCache(): Promise<void> {
     }
 
     local.key = key.key;
+    local.encryptedKey = key.encryptedKey;
     local.createdAt = key.createdAt;
     if (!(local.status === "invalid" && key.status !== "invalid")) {
       local.status = key.status;
@@ -44,12 +74,57 @@ export async function kvGetApiKeyById(id: string): Promise<ApiKey | null> {
   const cached = state.cachedKeysById.get(id);
   if (cached) return cached;
 
-  const entry = await state.kv.get<ApiKey>([...API_KEY_PREFIX, id]);
+  const entry = await state.kv.get<PersistedApiKey>([...API_KEY_PREFIX, id]);
   if (!entry.value) return null;
 
-  state.cachedKeysById.set(id, entry.value);
+  const hydrated = await hydrateApiKey(entry.value);
+  state.cachedKeysById.set(id, hydrated);
   rebuildActiveKeyIds();
-  return entry.value;
+  return hydrated;
+}
+
+export async function kvMigrateApiKeysToEncrypted(): Promise<number> {
+  let migrated = 0;
+  const iter = state.kv.list({ prefix: API_KEY_PREFIX });
+  for await (const entry of iter) {
+    const value = entry.value as Partial<LegacyApiKey> & Partial<ApiKey>;
+    if (typeof value.encryptedKey === "string") continue;
+    if (typeof value.key !== "string") {
+      throw new Error("API key 迁移失败：旧记录缺少明文 key");
+    }
+
+    const encryptedKey = await encryptApiKey(value.key);
+    const migratedValue = {
+      id: value.id,
+      useCount: value.useCount,
+      lastUsed: value.lastUsed,
+      status: value.status,
+      createdAt: value.createdAt,
+      encryptedKey,
+    };
+    if (
+      typeof migratedValue.id !== "string" ||
+      typeof migratedValue.useCount !== "number" ||
+      typeof migratedValue.status !== "string" ||
+      typeof migratedValue.createdAt !== "number"
+    ) {
+      throw new Error("API key 迁移失败：旧记录结构不完整");
+    }
+    const result = await state.kv.atomic()
+      .check(entry)
+      .set(entry.key, migratedValue)
+      .commit();
+    if (!result.ok) throw new Error("API key 迁移失败：KV 写入冲突");
+    state.cachedKeysById.delete(migratedValue.id);
+    migrated++;
+  }
+  if (migrated > 0) {
+    state.cachedKeysById = new Map(
+      (await kvGetAllKeys()).map((key) => [key.id, key]),
+    );
+    rebuildActiveKeyIds();
+  }
+  return migrated;
 }
 
 let lastApiKeyCreatedAtMs = 0;
@@ -68,15 +143,17 @@ export async function kvAddKey(
     ? lastApiKeyCreatedAtMs + 1
     : now;
   lastApiKeyCreatedAtMs = createdAt;
+  const encryptedKey = await encryptApiKey(key);
   const newKey: ApiKey = {
     id,
+    encryptedKey,
     key,
     useCount: 0,
     status: "active",
     createdAt,
   };
 
-  await state.kv.set([...API_KEY_PREFIX, id], newKey);
+  await state.kv.set([...API_KEY_PREFIX, id], toPersistedApiKey(newKey));
   state.cachedKeysById.set(id, newKey);
   rebuildActiveKeyIds();
 
@@ -106,10 +183,10 @@ export async function kvUpdateKey(
 ): Promise<void> {
   const key = [...API_KEY_PREFIX, id];
   const existing = state.cachedKeysById.get(id) ??
-    (await state.kv.get<ApiKey>(key)).value;
+    (await kvGetApiKeyById(id));
   if (!existing) return;
   const updated = { ...existing, ...updates };
-  await state.kv.set(key, updated);
+  await state.kv.set(key, toPersistedApiKey(updated));
   state.cachedKeysById.set(id, updated);
   rebuildActiveKeyIds();
 }

--- a/src/kv/proxy-keys.ts
+++ b/src/kv/proxy-keys.ts
@@ -2,13 +2,27 @@ import type { ProxyAuthKey } from "../types.ts";
 import { MAX_PROXY_KEYS, PROXY_KEY_PREFIX } from "../constants.ts";
 import { generateProxyKey } from "../keys.ts";
 import { generateId } from "../utils.ts";
+import { hashProxyKey, isHashedProxyKey } from "../secrets.ts";
 import { state } from "../state.ts";
+
+type LegacyProxyAuthKey = Omit<ProxyAuthKey, "keyHash"> & { key: string };
+
+function assertCurrentProxyKey(value: unknown): ProxyAuthKey {
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.keyHash !== "string") {
+    throw new Error("proxy key 存储格式不兼容：需要先运行密钥迁移");
+  }
+  if (!isHashedProxyKey(raw.keyHash)) {
+    throw new Error("proxy key 哈希格式错误");
+  }
+  return raw as unknown as ProxyAuthKey;
+}
 
 export async function kvGetAllProxyKeys(): Promise<ProxyAuthKey[]> {
   const keys: ProxyAuthKey[] = [];
   const iter = state.kv.list({ prefix: PROXY_KEY_PREFIX });
   for await (const entry of iter) {
-    keys.push(entry.value as ProxyAuthKey);
+    keys.push(assertCurrentProxyKey(entry.value));
   }
   return keys;
 }
@@ -24,6 +38,52 @@ async function ensureProxyKeyCache(): Promise<Map<string, ProxyAuthKey>> {
   return next;
 }
 
+export async function kvMigrateProxyKeysToHashed(): Promise<number> {
+  let migrated = 0;
+  const iter = state.kv.list({ prefix: PROXY_KEY_PREFIX });
+  for await (const entry of iter) {
+    const value = entry.value as
+      & Partial<LegacyProxyAuthKey>
+      & Partial<ProxyAuthKey>;
+    if (typeof value.keyHash === "string") continue;
+    if (typeof value.key !== "string") {
+      throw new Error("proxy key 迁移失败：旧记录缺少明文 key");
+    }
+
+    const keyHash = await hashProxyKey(value.key);
+    const migratedValue = {
+      id: value.id,
+      keyHash,
+      name: value.name,
+      useCount: value.useCount,
+      lastUsed: value.lastUsed,
+      createdAt: value.createdAt,
+    };
+    if (
+      typeof migratedValue.id !== "string" ||
+      typeof migratedValue.name !== "string" ||
+      typeof migratedValue.useCount !== "number" ||
+      typeof migratedValue.createdAt !== "number"
+    ) {
+      throw new Error("proxy key 迁移失败：旧记录结构不完整");
+    }
+    const result = await state.kv.atomic()
+      .check(entry)
+      .set(entry.key, migratedValue)
+      .commit();
+    if (!result.ok) throw new Error("proxy key 迁移失败：KV 写入冲突");
+    state.cachedProxyKeys?.delete(migratedValue.id);
+    migrated++;
+  }
+  if (migrated > 0) {
+    state.cachedProxyKeys = new Map(
+      (await kvGetAllProxyKeys()).map((key) => [key.id, key]),
+    );
+    state.proxyKeyCacheLastLoadedAt = Date.now();
+  }
+  return migrated;
+}
+
 export async function kvGetProxyKeyById(
   id: string,
 ): Promise<ProxyAuthKey | null> {
@@ -34,8 +94,20 @@ export async function kvGetProxyKeyById(
   const entry = await state.kv.get<ProxyAuthKey>([...PROXY_KEY_PREFIX, id]);
   if (!entry.value) return null;
 
-  cachedKeys.set(id, entry.value);
-  return entry.value;
+  const current = assertCurrentProxyKey(entry.value);
+  cachedKeys.set(id, current);
+  return current;
+}
+
+export async function findProxyKeyIdBySecret(
+  secret: string,
+): Promise<string | null> {
+  const keyHash = await hashProxyKey(secret);
+  const cachedKeys = await ensureProxyKeyCache();
+  for (const [id, pk] of cachedKeys) {
+    if (pk.keyHash === keyHash) return id;
+  }
+  return null;
 }
 
 export async function kvAddProxyKey(
@@ -53,7 +125,7 @@ export async function kvAddProxyKey(
   const key = generateProxyKey();
   const newKey: ProxyAuthKey = {
     id,
-    key,
+    keyHash: await hashProxyKey(key),
     name: name || `密钥 ${cachedKeys.size + 1}`,
     useCount: 0,
     createdAt: Date.now(),

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,0 +1,129 @@
+const API_KEY_PREFIX = "v1$aes-gcm$";
+const PROXY_KEY_PREFIX = "v1$hmac-sha256$";
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(
+    Math.ceil(value.length / 4) * 4,
+    "=",
+  );
+  return Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
+}
+
+function bytesSource(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+}
+
+function secretMaterial(): Uint8Array {
+  const secret = Deno.env.get("KEY_ENCRYPTION_SECRET")?.trim();
+  if (!secret) {
+    throw new Error("KEY_ENCRYPTION_SECRET 未配置，禁止写入或读取密钥");
+  }
+  return new TextEncoder().encode(secret);
+}
+
+export function assertKeyEncryptionSecretConfigured(): void {
+  secretMaterial();
+}
+
+async function deriveAesKey(): Promise<CryptoKey> {
+  const material = secretMaterial();
+  const digest = await crypto.subtle.digest("SHA-256", bytesSource(material));
+  return crypto.subtle.importKey("raw", digest, "AES-GCM", false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+function deriveHmacKey(): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    bytesSource(secretMaterial()),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+export function isEncryptedApiKey(value: string): boolean {
+  return value.startsWith(API_KEY_PREFIX);
+}
+
+export function isHashedProxyKey(value: string): boolean {
+  return value.startsWith(PROXY_KEY_PREFIX);
+}
+
+export async function encryptApiKey(plaintext: string): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveAesKey();
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      bytesSource(new TextEncoder().encode(plaintext)),
+    ),
+  );
+  return `${API_KEY_PREFIX}${encodeBase64Url(iv)}$${
+    encodeBase64Url(ciphertext)
+  }`;
+}
+
+export async function decryptApiKey(stored: string): Promise<string> {
+  if (!isEncryptedApiKey(stored)) {
+    throw new Error("API key 存储格式不兼容：需要先运行密钥迁移");
+  }
+
+  const parts = stored.split("$");
+  if (parts.length !== 4 || parts[0] !== "v1" || parts[1] !== "aes-gcm") {
+    throw new Error("API key 密文格式错误");
+  }
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: bytesSource(decodeBase64Url(parts[2])) },
+    await deriveAesKey(),
+    bytesSource(decodeBase64Url(parts[3])),
+  );
+  return new TextDecoder().decode(plaintext);
+}
+
+export async function hashProxyKey(secret: string): Promise<string> {
+  const signature = new Uint8Array(
+    await crypto.subtle.sign(
+      "HMAC",
+      await deriveHmacKey(),
+      bytesSource(new TextEncoder().encode(secret)),
+    ),
+  );
+  return `${PROXY_KEY_PREFIX}${encodeBase64Url(signature)}`;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const maxLength = Math.max(a.length, b.length);
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < maxLength; i++) {
+    const left = i < a.length ? a.charCodeAt(i) : 0;
+    const right = i < b.length ? b.charCodeAt(i) : 0;
+    diff |= left ^ right;
+  }
+  return diff === 0;
+}
+
+export async function verifyProxyKey(
+  secret: string,
+  storedHash: string,
+): Promise<boolean> {
+  if (!isHashedProxyKey(storedHash)) {
+    throw new Error("proxy key 存储格式不兼容：需要先运行密钥迁移");
+  }
+  const expected = await hashProxyKey(secret);
+  return constantTimeEqual(expected, storedHash);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface ApiKey {
   id: string;
+  encryptedKey: string;
   key: string;
   useCount: number;
   lastUsed?: number;
@@ -9,7 +10,7 @@ export interface ApiKey {
 
 export interface ProxyAuthKey {
   id: string;
-  key: string;
+  keyHash: string;
   name: string;
   useCount: number;
   lastUsed?: number;

--- a/src/ui/admin.html
+++ b/src/ui/admin.html
@@ -90,7 +90,6 @@
     .item-info { flex: 1; min-width: 0; }
     body .item-primary, body.light .item-primary { display: flex; align-items: center; gap: 6px; color: #334155; font-size: 11px; margin-bottom: 2px; flex-wrap: wrap; }
     .key-text { font-family: 'JetBrains Mono', monospace; word-break: break-all; }
-    .key-actions { display: inline-flex; align-items: center; gap: 2px; flex-shrink: 0; }
     body .item-secondary, body.light .item-secondary { font-size: 10px; color: #64748b; display: flex; align-items: center; gap: 4px; }
     .status-badge { display: inline-block; padding: 2px 6px; border-radius: 4px; font-size: 9px; font-weight: 500; text-transform: uppercase; }
     body .status-active, body.light .status-active { background: rgba(22, 163, 74, 0.12); color: #16a34a; }
@@ -266,7 +265,7 @@
 
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
           <span class="section-title" style="margin: 0;">密钥列表</span>
-          <button class="btn btn-outline" onclick="exportAllKeys()">导出全部</button>
+          <button class="btn btn-outline" disabled>明文导出已禁用</button>
         </div>
         <div id="keysContainer"></div>
       </div>
@@ -298,6 +297,7 @@
           <label>密钥名称（可选）</label>
           <input type="text" id="proxyKeyName" class="form-control" placeholder="例如：移动端应用">
           <button class="btn" onclick="createProxyKey()" style="margin-top: 8px;" id="createProxyKeyBtn">创建密钥</button>
+          <div id="newProxyKeyPanel" class="empty-state" style="display: none; margin-top: 8px;"></div>
         </div>
 
         <div class="divider"></div>
@@ -681,64 +681,9 @@
             const keySpan = document.createElement('span');
             keySpan.className = 'key-text';
             keySpan.id = 'pk-' + k.id;
-            keySpan.textContent = String(k.key ?? '');
-
-            const toggleBtn = document.createElement('button');
-            toggleBtn.className = 'btn-icon';
-            toggleBtn.title = '查看完整密钥';
-            toggleBtn.addEventListener('click', () => toggleProxyKeyVisibility(k.id));
-
-            const svgNs = 'http://www.w3.org/2000/svg';
-
-            const eyeIcon = document.createElementNS(svgNs, 'svg');
-            eyeIcon.id = 'pk-eye-' + k.id;
-            eyeIcon.setAttribute('xmlns', svgNs);
-            eyeIcon.setAttribute('width', '12');
-            eyeIcon.setAttribute('height', '12');
-            eyeIcon.setAttribute('viewBox', '0 0 24 24');
-            eyeIcon.setAttribute('fill', 'none');
-            eyeIcon.setAttribute('stroke', 'currentColor');
-            eyeIcon.setAttribute('stroke-width', '2');
-
-            const eyePath = document.createElementNS(svgNs, 'path');
-            eyePath.setAttribute('d', 'M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z');
-
-            const eyeCircle = document.createElementNS(svgNs, 'circle');
-            eyeCircle.setAttribute('cx', '12');
-            eyeCircle.setAttribute('cy', '12');
-            eyeCircle.setAttribute('r', '3');
-
-            eyeIcon.appendChild(eyePath);
-            eyeIcon.appendChild(eyeCircle);
-
-            const eyeOffIcon = document.createElementNS(svgNs, 'svg');
-            eyeOffIcon.id = 'pk-eye-off-' + k.id;
-            eyeOffIcon.setAttribute('xmlns', svgNs);
-            eyeOffIcon.setAttribute('width', '12');
-            eyeOffIcon.setAttribute('height', '12');
-            eyeOffIcon.setAttribute('viewBox', '0 0 24 24');
-            eyeOffIcon.setAttribute('fill', 'none');
-            eyeOffIcon.setAttribute('stroke', 'currentColor');
-            eyeOffIcon.setAttribute('stroke-width', '2');
-            eyeOffIcon.style.display = 'none';
-
-            const eyeOffPath = document.createElementNS(svgNs, 'path');
-            eyeOffPath.setAttribute('d', 'M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24');
-
-            const eyeOffLine = document.createElementNS(svgNs, 'line');
-            eyeOffLine.setAttribute('x1', '1');
-            eyeOffLine.setAttribute('y1', '1');
-            eyeOffLine.setAttribute('x2', '23');
-            eyeOffLine.setAttribute('y2', '23');
-
-            eyeOffIcon.appendChild(eyeOffPath);
-            eyeOffIcon.appendChild(eyeOffLine);
-
-            toggleBtn.appendChild(eyeIcon);
-            toggleBtn.appendChild(eyeOffIcon);
+            keySpan.textContent = 'ID: ' + String(k.id);
 
             primary.appendChild(keySpan);
-            primary.appendChild(toggleBtn);
 
             const secondary = document.createElement('div');
             secondary.className = 'item-secondary';
@@ -750,19 +695,12 @@
             const actions = document.createElement('div');
             actions.className = 'item-actions';
 
-            const copyBtn = document.createElement('button');
-            copyBtn.className = 'btn btn-outline';
-            copyBtn.textContent = '复制';
-            copyBtn.addEventListener('click', () => copyProxyKey(k.id));
-
             const deleteBtn = document.createElement('button');
             deleteBtn.className = 'btn btn-danger';
             deleteBtn.textContent = '删除';
             deleteBtn.addEventListener('click', () => deleteProxyKey(k.id));
 
-            actions.appendChild(copyBtn);
             actions.appendChild(deleteBtn);
-
             item.appendChild(info);
             item.appendChild(actions);
 
@@ -780,6 +718,9 @@
 
     async function createProxyKey() {
       const name = document.getElementById('proxyKeyName').value.trim();
+      const panel = document.getElementById('newProxyKeyPanel');
+      panel.style.display = 'none';
+      panel.textContent = '';
       try {
         const res = await fetch('/api/proxy-keys', { method: 'POST', headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' }, body: JSON.stringify({ name }) });
         const data = await res.json().catch(() => ({}));
@@ -789,6 +730,8 @@
           return;
         }
 
+        panel.textContent = '新代理密钥（只显示一次）：' + String(data.key);
+        panel.style.display = 'block';
         showNotification('密钥已创建，请立即复制保存');
         document.getElementById('proxyKeyName').value = '';
         loadProxyKeys();
@@ -810,41 +753,6 @@
       } catch (e) { showNotification('错误: ' + formatClientError(e), 'error'); }
     }
 
-    const proxyKeyFullValues = {};
-    async function toggleProxyKeyVisibility(id) {
-      const keySpan = document.getElementById('pk-' + id);
-      const eyeIcon = document.getElementById('pk-eye-' + id);
-      const eyeOffIcon = document.getElementById('pk-eye-off-' + id);
-      if (eyeIcon.style.display !== 'none') {
-        if (!proxyKeyFullValues[id]) {
-          try {
-            const res = await fetch('/api/proxy-keys/' + id + '/export', { headers: getAuthHeaders() });
-            const data = await res.json().catch(() => ({}));
-            if (handleUnauthorized(res)) return;
-            if (res.ok && data.key) proxyKeyFullValues[id] = data.key;
-          } catch (e) { return; }
-        }
-        if (proxyKeyFullValues[id]) {
-          keySpan.textContent = proxyKeyFullValues[id];
-          eyeIcon.style.display = 'none';
-          eyeOffIcon.style.display = 'inline';
-        }
-      } else { loadProxyKeys(); }
-    }
-
-    async function copyProxyKey(id) {
-      try {
-        const res = await fetch('/api/proxy-keys/' + id + '/export', { headers: getAuthHeaders() });
-        const data = await res.json().catch(() => ({}));
-        if (handleUnauthorized(res)) return;
-        if (!res.ok) {
-          showNotification(getApiErrorMessage(res, data) || '复制失败', 'error');
-          return;
-        }
-        if (data.key) { await navigator.clipboard.writeText(data.key); showNotification('密钥已复制'); }
-        else showNotification('复制失败', 'error');
-      } catch (e) { showNotification('错误: ' + formatClientError(e), 'error'); }
-    }
 
     // API 密钥管理
     async function addSingleKey() {
@@ -917,99 +825,9 @@
             const keySpan = document.createElement('span');
             keySpan.className = 'key-text';
             keySpan.id = 'key-' + k.id;
-            keySpan.textContent = String(k.key ?? '');
-
-            const keyActions = document.createElement('span');
-            keyActions.className = 'key-actions';
-
-            const svgNs = 'http://www.w3.org/2000/svg';
-
-            const toggleBtn = document.createElement('button');
-            toggleBtn.className = 'btn-icon';
-            toggleBtn.title = '查看完整密钥';
-            toggleBtn.addEventListener('click', () => toggleKeyVisibility(k.id));
-
-            const eyeIcon = document.createElementNS(svgNs, 'svg');
-            eyeIcon.id = 'eye-' + k.id;
-            eyeIcon.setAttribute('xmlns', svgNs);
-            eyeIcon.setAttribute('width', '14');
-            eyeIcon.setAttribute('height', '14');
-            eyeIcon.setAttribute('viewBox', '0 0 24 24');
-            eyeIcon.setAttribute('fill', 'none');
-            eyeIcon.setAttribute('stroke', 'currentColor');
-            eyeIcon.setAttribute('stroke-width', '2');
-
-            const eyePath = document.createElementNS(svgNs, 'path');
-            eyePath.setAttribute('d', 'M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z');
-
-            const eyeCircle = document.createElementNS(svgNs, 'circle');
-            eyeCircle.setAttribute('cx', '12');
-            eyeCircle.setAttribute('cy', '12');
-            eyeCircle.setAttribute('r', '3');
-
-            eyeIcon.appendChild(eyePath);
-            eyeIcon.appendChild(eyeCircle);
-
-            const eyeOffIcon = document.createElementNS(svgNs, 'svg');
-            eyeOffIcon.id = 'eye-off-' + k.id;
-            eyeOffIcon.setAttribute('xmlns', svgNs);
-            eyeOffIcon.setAttribute('width', '14');
-            eyeOffIcon.setAttribute('height', '14');
-            eyeOffIcon.setAttribute('viewBox', '0 0 24 24');
-            eyeOffIcon.setAttribute('fill', 'none');
-            eyeOffIcon.setAttribute('stroke', 'currentColor');
-            eyeOffIcon.setAttribute('stroke-width', '2');
-            eyeOffIcon.style.display = 'none';
-
-            const eyeOffPath = document.createElementNS(svgNs, 'path');
-            eyeOffPath.setAttribute('d', 'M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24');
-
-            const eyeOffLine = document.createElementNS(svgNs, 'line');
-            eyeOffLine.setAttribute('x1', '1');
-            eyeOffLine.setAttribute('y1', '1');
-            eyeOffLine.setAttribute('x2', '23');
-            eyeOffLine.setAttribute('y2', '23');
-
-            eyeOffIcon.appendChild(eyeOffPath);
-            eyeOffIcon.appendChild(eyeOffLine);
-
-            toggleBtn.appendChild(eyeIcon);
-            toggleBtn.appendChild(eyeOffIcon);
-
-            const copyBtn = document.createElement('button');
-            copyBtn.className = 'btn-icon';
-            copyBtn.title = '复制密钥';
-            copyBtn.addEventListener('click', () => copyKey(k.id));
-
-            const copySvg = document.createElementNS(svgNs, 'svg');
-            copySvg.setAttribute('xmlns', svgNs);
-            copySvg.setAttribute('width', '14');
-            copySvg.setAttribute('height', '14');
-            copySvg.setAttribute('viewBox', '0 0 24 24');
-            copySvg.setAttribute('fill', 'none');
-            copySvg.setAttribute('stroke', 'currentColor');
-            copySvg.setAttribute('stroke-width', '2');
-
-            const copyRect = document.createElementNS(svgNs, 'rect');
-            copyRect.setAttribute('x', '9');
-            copyRect.setAttribute('y', '9');
-            copyRect.setAttribute('width', '13');
-            copyRect.setAttribute('height', '13');
-            copyRect.setAttribute('rx', '2');
-            copyRect.setAttribute('ry', '2');
-
-            const copyPath = document.createElementNS(svgNs, 'path');
-            copyPath.setAttribute('d', 'M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1');
-
-            copySvg.appendChild(copyRect);
-            copySvg.appendChild(copyPath);
-            copyBtn.appendChild(copySvg);
-
-            keyActions.appendChild(toggleBtn);
-            keyActions.appendChild(copyBtn);
+            keySpan.textContent = 'ID: ' + String(k.id);
 
             primary.appendChild(keySpan);
-            primary.appendChild(keyActions);
 
             const secondary = document.createElement('div');
             secondary.className = 'item-secondary';
@@ -1069,41 +887,6 @@
       } catch (e) { showNotification('加载统计失败: ' + formatClientError(e), 'error'); }
     }
 
-    async function copyKey(id) {
-      try {
-        const res = await fetch('/api/keys/' + id + '/export', { headers: getAuthHeaders() });
-        const data = await res.json().catch(() => ({}));
-        if (handleUnauthorized(res)) return;
-        if (!res.ok) {
-          showNotification(getApiErrorMessage(res, data) || '复制失败', 'error');
-          return;
-        }
-        if (data.key) {
-          await navigator.clipboard.writeText(data.key);
-          showNotification('密钥已复制');
-        } else {
-          showNotification('复制失败', 'error');
-        }
-      } catch (e) { showNotification('错误: ' + formatClientError(e), 'error'); }
-    }
-
-    const keyFullValues = {};
-    async function toggleKeyVisibility(id) {
-      const keySpan = document.getElementById('key-' + id);
-      const eyeIcon = document.getElementById('eye-' + id);
-      const eyeOffIcon = document.getElementById('eye-off-' + id);
-      if (eyeIcon.style.display !== 'none') {
-        if (!keyFullValues[id]) {
-          try {
-            const res = await fetch('/api/keys/' + id + '/export', { headers: getAuthHeaders() });
-            const data = await res.json().catch(() => ({}));
-            if (handleUnauthorized(res)) return;
-            if (res.ok && data.key) keyFullValues[id] = data.key;
-          } catch (e) { return; }
-        }
-        if (keyFullValues[id]) { keySpan.textContent = keyFullValues[id]; eyeIcon.style.display = 'none'; eyeOffIcon.style.display = 'inline'; }
-      } else { loadKeys(); }
-    }
 
     async function deleteKey(id) {
       if (!confirm('删除此密钥？')) return;
@@ -1145,19 +928,6 @@
       }
     }
 
-    async function exportAllKeys() {
-      try {
-        const res = await fetch('/api/keys/export', { headers: getAuthHeaders() });
-        const data = await res.json().catch(() => ({}));
-        if (handleUnauthorized(res)) return;
-        if (!res.ok) {
-          showNotification(getApiErrorMessage(res, data) || '导出失败', 'error');
-          return;
-        }
-        if (data.keys?.length > 0) { await navigator.clipboard.writeText(data.keys.join('\\n')); showNotification(`${data.keys.length} 个密钥已复制`); }
-        else showNotification('没有密钥可导出', 'error');
-      } catch (e) { showNotification('错误: ' + formatClientError(e), 'error'); }
-    }
 
     // 模型管理
     function formatTimestamp(ms) {


### PR DESCRIPTION
## 变更

- 新增 `KEY_ENCRYPTION_SECRET`，启动与密钥读写时强制校验，缺失时失败而不是降级。
- Cerebras API key 写入 KV 前使用 AES-GCM 加密，KV 中不再保存明文字段。
- 代理访问密钥只在创建响应中返回一次，KV 中只保存 HMAC-SHA-256 哈希。
- 禁用 API key 与 proxy key 的明文导出接口，并移除管理页列表中的明文/掩码展示路径。
- 增加旧明文 API key/proxy key 迁移接口，迁移后旧 token 仍可继续使用。
- 更新部署与 API 文档，补充 `KEY_ENCRYPTION_SECRET` 和迁移接口说明。

## 说明

这是 #118 的 main replacement。原 #118 已关闭，本 PR 从当前 `main` 重新落地同一安全整改。

## 验证

- `deno check main.ts src`
- `deno fmt --check main.ts src README.md docs/API.md docs/DEPLOYMENT_DOCKER.md docs/DEPLOYMENT_VPS.md docs/GUIDE.md docs/TECH_DETAILS.md`
- `deno lint main.ts src`
- `deno test --allow-net --allow-env --allow-read --allow-write src/__tests__/integration_test.ts src/__tests__/api-keys_test.ts src/__tests__/auth_test.ts src/__tests__/services_test.ts src/__tests__/stream-limits_test.ts src/__tests__/secrets_test.ts`

Closes #109