### PR TITLE
修复流式响应清理竞态

### DIFF
--- a/src/__tests__/stream-limits_test.ts
+++ b/src/__tests__/stream-limits_test.ts
@@ -75,6 +75,64 @@ Deno.test("boundProxyResponseBody - rejects response body over byte limit", asyn
   assertEquals(released, true);
 });
 
+Deno.test("boundProxyResponseBody - releases when source cancel rejects", async () => {
+  let released = false;
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1]));
+    },
+    cancel() {
+      throw new Error("cancel failed");
+    },
+  });
+
+  const reader = boundProxyResponseBody(
+    source,
+    () => {
+      released = true;
+      return Promise.resolve();
+    },
+    { maxBytes: 1024, totalTimeoutMs: 1000, idleTimeoutMs: 1000 },
+  ).getReader();
+
+  assertEquals((await reader.read()).done, false);
+  await assertRejects(
+    () => reader.cancel("client gone"),
+    Error,
+    "cancel failed",
+  );
+
+  assertEquals(released, true);
+});
+
+Deno.test("boundProxyResponseBody - releases when timeout races with pull error", async () => {
+  let readRejected = false;
+  let released = false;
+  const source = new ReadableStream<Uint8Array>({
+    pull() {
+      readRejected = true;
+      throw new Error("read failed");
+    },
+    cancel() {
+      throw new Error("cancel failed");
+    },
+  });
+
+  const reader = boundProxyResponseBody(
+    source,
+    () => {
+      released = true;
+      return Promise.resolve();
+    },
+    { maxBytes: 1024, totalTimeoutMs: 0, idleTimeoutMs: 1000 },
+  ).getReader();
+
+  await assertRejects(() => reader.read(), Error);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assertEquals(readRejected, true);
+  assertEquals(released, true);
+});
 Deno.test("acquireProxyStreamSlots - enforces public bucket concurrency", async () => {
   const kv = await setupKv();
 

--- a/src/stream-limits.ts
+++ b/src/stream-limits.ts
@@ -183,19 +183,35 @@ export function boundProxyResponseBody(
     return releaseOnce();
   }
 
+  function errorController(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    error: unknown,
+  ): void {
+    try {
+      controller.error(error);
+    } catch (caught) {
+      if (caught instanceof TypeError) return;
+      throw caught;
+    }
+  }
+
   async function fail(
     controller: ReadableStreamDefaultController<Uint8Array>,
     message: string,
     metricLabel: string,
   ): Promise<void> {
+    if (finished) return;
     finished = true;
     clearTimers();
     metrics.inc("proxy_requests_total", metricLabel);
-    controller.error(new Error(message));
     try {
-      await reader.cancel(message);
+      errorController(controller, new Error(message));
     } finally {
-      await releaseOnce();
+      try {
+        await reader.cancel(message);
+      } finally {
+        await releaseOnce();
+      }
     }
   }
 
@@ -234,13 +250,22 @@ export function boundProxyResponseBody(
         controller.enqueue(value);
         scheduleIdle(controller);
       } catch (error) {
-        await finish();
-        controller.error(error);
+        const alreadyFinished = finished;
+        try {
+          if (!alreadyFinished) errorController(controller, error);
+        } finally {
+          await finish();
+        }
       }
     },
     async cancel(reason) {
-      await reader.cancel(reason);
-      await finish();
+      if (finished) return;
+      finished = true;
+      try {
+        await reader.cancel(reason);
+      } finally {
+        await releaseOnce();
+      }
     },
   });
 }


### PR DESCRIPTION
## 变更

- 确保下游取消时即使 upstream `reader.cancel()` 抛错也会释放 stream slot。
- 在超时/超大响应触发 `controller.error()` 后仍强制取消 upstream reader 并释放 slot。
- 避免 pull 错误与超时竞态重复操作已完成的 stream controller。
- 增加 cleanup race 回归测试。

## 验证

- `deno check main.ts src`
- `deno fmt --check main.ts src README.md docs/API.md docs/DEPLOYMENT_DOCKER.md docs/DEPLOYMENT_VPS.md docs/GUIDE.md docs/TECH_DETAILS.md`
- `deno lint main.ts src`
- `deno test --allow-net --allow-env --allow-read --allow-write src/__tests__/stream-limits_test.ts src/__tests__/integration_test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 新增流限制错误处理的测试用例，验证异常场景下的流资源释放和错误触发行为。

* **Bug Fixes**
  * 改进流错误处理机制，增强防御性设计，确保在异常情况下仍能正确释放资源。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->