### PR TITLE
fix(security): harden cache revocation

### DIFF
--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -12,6 +12,7 @@ import { resetProxyStreamCountersForTests } from "../stream-limits.ts";
 import { metrics } from "../metrics.ts";
 import {
   ADMIN_CORS_HEADERS,
+  ADMIN_TOKEN_PREFIX,
   API_KEY_PREFIX,
   CEREBRAS_API_URL,
   CORS_HEADERS,
@@ -25,8 +26,16 @@ import {
   PROXY_REQUEST_BODY_IDLE_TIMEOUT_MS,
   PROXY_UNAUTHORIZED_RATE_LIMIT_MAX,
 } from "../constants.ts";
-import { rebuildActiveKeyIds } from "../api-keys.ts";
-import { encryptApiKey } from "../secrets.ts";
+import {
+  rebuildActiveKeyIds,
+  refreshApiKeyCacheIfChanged,
+} from "../api-keys.ts";
+import { encryptApiKey, hashProxyKey } from "../secrets.ts";
+import {
+  createAdminToken,
+  isProxyAuthorized,
+  verifyAdminToken,
+} from "../auth.ts";
 import { readBoundedTextForTests } from "../proxy-validation.ts";
 const BASE = "http://localhost";
 
@@ -215,6 +224,23 @@ Deno.test("integration: auth setup → login → logout", async () => {
     }),
   )).json();
   assertEquals(status3.isLoggedIn, false);
+
+  kv.close();
+});
+
+Deno.test("integration: admin session tokens are stored as keyed digests", async () => {
+  const kv = await setupKv();
+
+  const token = await createAdminToken();
+  const plaintextEntry = await kv.get([...ADMIN_TOKEN_PREFIX, token]);
+  assertEquals(plaintextEntry.value, null);
+
+  const digestEntry = await kv.get([
+    ...ADMIN_TOKEN_PREFIX,
+    await hashProxyKey(token),
+  ]);
+  assertEquals(typeof digestEntry.value, "number");
+  assertEquals(await verifyAdminToken(token), true);
 
   kv.close();
 });
@@ -581,6 +607,53 @@ Deno.test("integration: proxy key add → list → delete", async () => {
   kv.close();
 });
 
+Deno.test("integration: proxy auth refreshes stale cache after revocation revision", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await setupAuth(handler);
+
+  const addRes = await handler(
+    makeReq("POST", "/api/proxy-keys", {
+      headers: { "X-Admin-Token": token },
+      body: { name: "revoked" },
+    }),
+  );
+  const { id, key } = await addRes.json();
+  state.proxyKeyCacheLastLoadedAt = 0;
+  assertEquals(
+    (await isProxyAuthorized(
+      makeReq("POST", "/v1/chat/completions", {
+        headers: { Authorization: `Bearer ${key}` },
+      }),
+    )).authorized,
+    true,
+  );
+
+  await handler(
+    makeReq("DELETE", `/api/proxy-keys/${id}`, {
+      headers: { "X-Admin-Token": token },
+    }),
+  );
+  state.cachedProxyKeys?.set(id, {
+    id,
+    keyHash: await hashProxyKey(key),
+    name: "stale",
+    useCount: 0,
+    createdAt: Date.now(),
+  });
+  state.proxyKeyCacheLastLoadedAt = 0;
+  state.authCacheRevision = 0;
+
+  const auth = await isProxyAuthorized(
+    makeReq("POST", "/v1/chat/completions", {
+      headers: { Authorization: `Bearer ${key}` },
+    }),
+  );
+  assertEquals(auth.authorized, false);
+
+  kv.close();
+});
+
 Deno.test("integration: proxy key list errors are structured", async () => {
   const kv = await setupKv();
   const handler = buildHandler();
@@ -902,6 +975,30 @@ Deno.test("integration: proxy explicit public mode allows requests without keys"
   kv.close();
 });
 
+Deno.test("integration: public access cache refreshes after config revision", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await enableProxyPublicAccess(handler);
+
+  state.cachedConfig!.proxyPublicAccess = true;
+  await handler(
+    makeReq("PATCH", "/api/config", {
+      headers: { "X-Admin-Token": token },
+      body: { proxyPublicAccess: false },
+    }),
+  );
+  state.cachedConfig!.proxyPublicAccess = true;
+  state.proxyKeyCacheLastLoadedAt = 0;
+  state.authCacheRevision = 0;
+
+  const auth = await isProxyAuthorized(
+    makeReq("POST", "/v1/chat/completions"),
+  );
+  assertEquals(auth.authorized, false);
+
+  kv.close();
+});
+
 Deno.test("integration: proxy invalid tokens do not repeatedly reload empty cache", async () => {
   const kv = await setupKv();
   const handler = buildHandler();
@@ -1170,6 +1267,25 @@ Deno.test("integration: upstream 401 invalidation does not persist plaintext API
     restoreFetch();
     kv.close();
   }
+});
+
+Deno.test("integration: API key cache evicts stale deleted keys after revision", async () => {
+  const kv = await setupKv();
+  await addActiveApiKey("sk-stale-secret");
+  const [apiKeyId] = state.cachedActiveKeyIds;
+
+  await kv.delete([...API_KEY_PREFIX, apiKeyId]);
+  await kv.set(
+    ["cerebras-proxy", "meta", "api_key_cache_revision"],
+    Date.now(),
+  );
+  state.apiKeyCacheRevision = 0;
+  await refreshApiKeyCacheIfChanged();
+
+  assertEquals(state.cachedKeysById.has(apiKeyId), false);
+  assertEquals(state.cachedActiveKeyIds.includes(apiKeyId), false);
+
+  kv.close();
 });
 
 Deno.test("integration: slow proxy request bodies are cancelled", async () => {

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -634,7 +634,10 @@ Deno.test("integration: proxy auth refreshes stale cache after revocation revisi
       headers: { "X-Admin-Token": token },
     }),
   );
-  state.cachedProxyKeys?.set(id, {
+  if (!state.cachedProxyKeys) {
+    throw new Error("proxy key cache not initialized");
+  }
+  state.cachedProxyKeys.set(id, {
     id,
     keyHash: await hashProxyKey(key),
     name: "stale",
@@ -643,6 +646,7 @@ Deno.test("integration: proxy auth refreshes stale cache after revocation revisi
   });
   state.proxyKeyCacheLastLoadedAt = 0;
   state.authCacheRevision = 0;
+  state.authCacheRevisionLastCheckedAt = 0;
 
   const auth = await isProxyAuthorized(
     makeReq("POST", "/v1/chat/completions", {
@@ -752,10 +756,10 @@ Deno.test("integration: proxy key creation errors do not expose stack traces", a
   const kv = await setupKv();
   const handler = buildHandler();
   const token = await setupAuth(handler);
-  const originalSet = state.kv.set;
-  state.kv.set = (() => {
+  const originalAtomic = state.kv.atomic;
+  state.kv.atomic = (() => {
     throw new Error("database password leaked");
-  }) as typeof state.kv.set;
+  }) as typeof state.kv.atomic;
 
   try {
     const res = await handler(
@@ -771,7 +775,7 @@ Deno.test("integration: proxy key creation errors do not expose stack traces", a
     assertEquals(bodyText.includes("Error:"), false);
     assertEquals(bodyText.includes("at "), false);
   } finally {
-    state.kv.set = originalSet;
+    state.kv.atomic = originalAtomic;
     kv.close();
   }
 });
@@ -990,6 +994,7 @@ Deno.test("integration: public access cache refreshes after config revision", as
   state.cachedConfig!.proxyPublicAccess = true;
   state.proxyKeyCacheLastLoadedAt = 0;
   state.authCacheRevision = 0;
+  state.authCacheRevisionLastCheckedAt = 0;
 
   const auth = await isProxyAuthorized(
     makeReq("POST", "/v1/chat/completions"),
@@ -1280,10 +1285,52 @@ Deno.test("integration: API key cache evicts stale deleted keys after revision",
     Date.now(),
   );
   state.apiKeyCacheRevision = 0;
+  state.apiKeyCacheRevisionLastCheckedAt = 0;
   await refreshApiKeyCacheIfChanged();
 
   assertEquals(state.cachedKeysById.has(apiKeyId), false);
   assertEquals(state.cachedActiveKeyIds.includes(apiKeyId), false);
+
+  kv.close();
+});
+
+Deno.test("integration: API key revision refresh retries after merge failure", async () => {
+  const kv = await setupKv();
+  await addActiveApiKey("sk-retry-secret");
+  const [apiKeyId] = state.cachedActiveKeyIds;
+
+  await kv.delete([...API_KEY_PREFIX, apiKeyId]);
+  await kv.set(
+    ["cerebras-proxy", "meta", "api_key_cache_revision"],
+    Date.now(),
+  );
+  state.apiKeyCacheRevision = 0;
+  state.apiKeyCacheRevisionLastCheckedAt = 0;
+
+  const originalList = state.kv.list.bind(state.kv);
+  let failed = false;
+  state.kv.list = ((
+    selector: Deno.KvListSelector,
+    options?: Deno.KvListOptions,
+  ) => {
+    if (!failed) {
+      failed = true;
+      throw new Error("transient list failure");
+    }
+    return originalList(selector, options);
+  }) as typeof state.kv.list;
+
+  await assertRejects(
+    () => refreshApiKeyCacheIfChanged(),
+    Error,
+    "transient list failure",
+  );
+  assertEquals(state.apiKeyCacheRevision, 0);
+  state.kv.list = originalList;
+  state.apiKeyCacheRevisionLastCheckedAt = 0;
+
+  await refreshApiKeyCacheIfChanged();
+  assertEquals(state.cachedKeysById.has(apiKeyId), false);
 
   kv.close();
 });

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -1,4 +1,7 @@
-import { API_KEY_PREFIX } from "./constants.ts";
+import {
+  API_KEY_PREFIX,
+  PROXY_KEY_AUTH_REFRESH_INTERVAL_MS,
+} from "./constants.ts";
 import { toPersistedApiKey } from "./api-key-record.ts";
 import { state } from "./state.ts";
 import { getApiKeyCacheRevision } from "./kv/revisions.ts";
@@ -54,11 +57,18 @@ export function getNextApiKeyFast(
 }
 
 export async function refreshApiKeyCacheIfChanged(): Promise<void> {
+  const now = Date.now();
+  if (
+    now - state.apiKeyCacheRevisionLastCheckedAt <
+      PROXY_KEY_AUTH_REFRESH_INTERVAL_MS
+  ) {
+    return;
+  }
   const revision = await getApiKeyCacheRevision();
-  state.apiKeyCacheRevisionLastCheckedAt = Date.now();
+  state.apiKeyCacheRevisionLastCheckedAt = now;
   if (revision === state.apiKeyCacheRevision) return;
-  state.apiKeyCacheRevision = revision;
   await kvMergeAllApiKeysIntoCache();
+  state.apiKeyCacheRevision = revision;
 }
 
 export function markKeyCooldownFrom429(id: string, response: Response): void {

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -1,6 +1,8 @@
 import { API_KEY_PREFIX } from "./constants.ts";
 import { toPersistedApiKey } from "./api-key-record.ts";
 import { state } from "./state.ts";
+import { getApiKeyCacheRevision } from "./kv/revisions.ts";
+import { kvMergeAllApiKeysIntoCache } from "./kv/api-keys.ts";
 
 export function rebuildActiveKeyIds(): void {
   const keys = Array.from(state.cachedKeysById.values());
@@ -49,6 +51,14 @@ export function getNextApiKeyFast(
   }
 
   return null;
+}
+
+export async function refreshApiKeyCacheIfChanged(): Promise<void> {
+  const revision = await getApiKeyCacheRevision();
+  state.apiKeyCacheRevisionLastCheckedAt = Date.now();
+  if (revision === state.apiKeyCacheRevision) return;
+  state.apiKeyCacheRevision = revision;
+  await kvMergeAllApiKeysIntoCache();
 }
 
 export function markKeyCooldownFrom429(id: string, response: Response): void {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,8 +6,11 @@ import {
 } from "./constants.ts";
 import { hashPassword, verifyPbkdf2Password } from "./crypto.ts";
 import { state } from "./state.ts";
+import { kvGetConfig } from "./kv/config.ts";
+import { getAuthCacheRevision } from "./kv/revisions.ts";
 import { findProxyKeyIdBySecret, kvGetAllProxyKeys } from "./kv/proxy-keys.ts";
 import type { ProxyAuthKey } from "./types.ts";
+import { hashProxyKey } from "./secrets.ts";
 
 // Admin password management
 /**
@@ -53,9 +56,13 @@ export async function verifyAdminPassword(password: string): Promise<boolean> {
 export async function createAdminToken(): Promise<string> {
   const token = crypto.randomUUID();
   const expiry = Date.now() + ADMIN_TOKEN_EXPIRY_MS;
-  await state.kv.set([...ADMIN_TOKEN_PREFIX, token], expiry, {
-    expireIn: ADMIN_TOKEN_EXPIRY_MS,
-  });
+  await state.kv.set(
+    [...ADMIN_TOKEN_PREFIX, await hashProxyKey(token)],
+    expiry,
+    {
+      expireIn: ADMIN_TOKEN_EXPIRY_MS,
+    },
+  );
   return token;
 }
 
@@ -64,10 +71,11 @@ export async function createAdminToken(): Promise<string> {
  */
 export async function verifyAdminToken(token: string | null): Promise<boolean> {
   if (!token) return false;
-  const entry = await state.kv.get<number>([...ADMIN_TOKEN_PREFIX, token]);
+  const tokenKey = [...ADMIN_TOKEN_PREFIX, await hashProxyKey(token)];
+  const entry = await state.kv.get<number>(tokenKey);
   if (!entry.value) return false;
   if (Date.now() > entry.value) {
-    await state.kv.delete([...ADMIN_TOKEN_PREFIX, token]);
+    await state.kv.delete(tokenKey);
     return false;
   }
   return true;
@@ -77,7 +85,7 @@ export async function verifyAdminToken(token: string | null): Promise<boolean> {
  * Deletes an admin session token; missing tokens are already logged out.
  */
 export async function deleteAdminToken(token: string): Promise<void> {
-  await state.kv.delete([...ADMIN_TOKEN_PREFIX, token]);
+  await state.kv.delete([...ADMIN_TOKEN_PREFIX, await hashProxyKey(token)]);
 }
 
 /**
@@ -116,6 +124,16 @@ async function refreshProxyKeyCache(): Promise<Map<string, ProxyAuthKey>> {
   }
 }
 
+async function refreshAuthCacheIfChanged(): Promise<void> {
+  if (!shouldRefreshProxyKeyCache()) return;
+  const revision = await getAuthCacheRevision();
+  state.authCacheRevisionLastCheckedAt = Date.now();
+  if (revision === state.authCacheRevision) return;
+  state.authCacheRevision = revision;
+  state.cachedConfig = await kvGetConfig();
+  await refreshProxyKeyCache();
+}
+
 function shouldRefreshProxyKeyCache(): boolean {
   return Date.now() - state.proxyKeyCacheLastLoadedAt >=
     PROXY_KEY_AUTH_REFRESH_INTERVAL_MS;
@@ -128,6 +146,7 @@ function shouldRefreshProxyKeyCache(): boolean {
 export async function isProxyAuthorized(
   req: Request,
 ): Promise<{ authorized: boolean; keyId?: string }> {
+  await refreshAuthCacheIfChanged();
   if (state.cachedConfig?.proxyPublicAccess === true) {
     return { authorized: true };
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -125,13 +125,19 @@ async function refreshProxyKeyCache(): Promise<Map<string, ProxyAuthKey>> {
 }
 
 async function refreshAuthCacheIfChanged(): Promise<void> {
-  if (!shouldRefreshProxyKeyCache()) return;
+  const now = Date.now();
+  if (
+    now - state.authCacheRevisionLastCheckedAt <
+      PROXY_KEY_AUTH_REFRESH_INTERVAL_MS
+  ) {
+    return;
+  }
   const revision = await getAuthCacheRevision();
-  state.authCacheRevisionLastCheckedAt = Date.now();
+  state.authCacheRevisionLastCheckedAt = now;
   if (revision === state.authCacheRevision) return;
-  state.authCacheRevision = revision;
   state.cachedConfig = await kvGetConfig();
   await refreshProxyKeyCache();
+  state.authCacheRevision = revision;
 }
 
 function shouldRefreshProxyKeyCache(): boolean {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,16 @@ export const ADMIN_PASSWORD_KEY = [
   "admin_password",
 ] as const;
 export const ADMIN_TOKEN_PREFIX = [KV_PREFIX, "auth", "token"] as const;
+export const AUTH_CACHE_REVISION_KEY = [
+  KV_PREFIX,
+  "meta",
+  "auth_cache_revision",
+] as const;
+export const API_KEY_CACHE_REVISION_KEY = [
+  KV_PREFIX,
+  "meta",
+  "api_key_cache_revision",
+] as const;
 
 // Retry and limits
 export const KV_ATOMIC_MAX_RETRIES = 10;

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -1,11 +1,14 @@
 import type { ApiKey } from "../types.ts";
 import { type PersistedApiKey, toPersistedApiKey } from "../api-key-record.ts";
-import { API_KEY_PREFIX } from "../constants.ts";
+import { API_KEY_CACHE_REVISION_KEY, API_KEY_PREFIX } from "../constants.ts";
 import { generateId } from "../utils.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
 import { decryptApiKey, encryptApiKey, isEncryptedApiKey } from "../secrets.ts";
 import { state } from "../state.ts";
-import { bumpApiKeyCacheRevision } from "./revisions.ts";
+import {
+  getNextRevisionValue,
+  recordApiKeyCacheRevision,
+} from "./revisions.ts";
 
 type LegacyApiKey = Omit<ApiKey, "encryptedKey"> & { key: string };
 
@@ -156,10 +159,19 @@ export async function kvAddKey(
     createdAt,
   };
 
-  await state.kv.set([...API_KEY_PREFIX, id], toPersistedApiKey(newKey));
+  const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
+  const revision = getNextRevisionValue(revisionEntry);
+  const result = await state.kv.atomic()
+    .check(revisionEntry)
+    .set([...API_KEY_PREFIX, id], toPersistedApiKey(newKey))
+    .set(API_KEY_CACHE_REVISION_KEY, revision)
+    .commit();
+  if (!result.ok) {
+    return { success: false, error: "密钥保存失败，请重试" };
+  }
   state.cachedKeysById.set(id, newKey);
   rebuildActiveKeyIds();
-  await bumpApiKeyCacheRevision();
+  recordApiKeyCacheRevision(revision);
 
   return { success: true, id };
 }
@@ -173,12 +185,22 @@ export async function kvDeleteKey(
     return { success: false, error: "密钥不存在" };
   }
 
-  await state.kv.delete(key);
+  const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
+  const revision = getNextRevisionValue(revisionEntry);
+  const deleteResult = await state.kv.atomic()
+    .check(result)
+    .check(revisionEntry)
+    .delete(key)
+    .set(API_KEY_CACHE_REVISION_KEY, revision)
+    .commit();
+  if (!deleteResult.ok) {
+    return { success: false, error: "密钥删除失败，请重试" };
+  }
   state.cachedKeysById.delete(id);
   state.keyCooldownUntil.delete(id);
   state.dirtyKeyIds.delete(id);
   rebuildActiveKeyIds();
-  await bumpApiKeyCacheRevision();
+  recordApiKeyCacheRevision(revision);
   return { success: true };
 }
 
@@ -191,8 +213,18 @@ export async function kvUpdateKey(
     (await kvGetApiKeyById(id));
   if (!existing) return;
   const updated = { ...existing, ...updates };
-  await state.kv.set(key, toPersistedApiKey(updated));
+  const entry = await state.kv.get<PersistedApiKey>(key);
+  if (!entry.value) return;
+  const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
+  const revision = getNextRevisionValue(revisionEntry);
+  const result = await state.kv.atomic()
+    .check(entry)
+    .check(revisionEntry)
+    .set(key, toPersistedApiKey(updated))
+    .set(API_KEY_CACHE_REVISION_KEY, revision)
+    .commit();
+  if (!result.ok) throw new Error("密钥更新失败：KV 写入冲突");
   state.cachedKeysById.set(id, updated);
   rebuildActiveKeyIds();
-  await bumpApiKeyCacheRevision();
+  recordApiKeyCacheRevision(revision);
 }

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -5,6 +5,7 @@ import { generateId } from "../utils.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
 import { decryptApiKey, encryptApiKey, isEncryptedApiKey } from "../secrets.ts";
 import { state } from "../state.ts";
+import { bumpApiKeyCacheRevision } from "./revisions.ts";
 
 type LegacyApiKey = Omit<ApiKey, "encryptedKey"> & { key: string };
 
@@ -38,6 +39,14 @@ export async function kvGetAllKeys(): Promise<ApiKey[]> {
 
 export async function kvMergeAllApiKeysIntoCache(): Promise<void> {
   const keys = await kvGetAllKeys();
+  const loadedIds = new Set(keys.map((key) => key.id));
+  for (const id of state.cachedKeysById.keys()) {
+    if (!loadedIds.has(id)) {
+      state.cachedKeysById.delete(id);
+      state.keyCooldownUntil.delete(id);
+      state.dirtyKeyIds.delete(id);
+    }
+  }
   for (const key of keys) {
     const local = state.cachedKeysById.get(key.id);
     if (!local) {
@@ -150,6 +159,7 @@ export async function kvAddKey(
   await state.kv.set([...API_KEY_PREFIX, id], toPersistedApiKey(newKey));
   state.cachedKeysById.set(id, newKey);
   rebuildActiveKeyIds();
+  await bumpApiKeyCacheRevision();
 
   return { success: true, id };
 }
@@ -168,6 +178,7 @@ export async function kvDeleteKey(
   state.keyCooldownUntil.delete(id);
   state.dirtyKeyIds.delete(id);
   rebuildActiveKeyIds();
+  await bumpApiKeyCacheRevision();
   return { success: true };
 }
 
@@ -183,4 +194,5 @@ export async function kvUpdateKey(
   await state.kv.set(key, toPersistedApiKey(updated));
   state.cachedKeysById.set(id, updated);
   rebuildActiveKeyIds();
+  await bumpApiKeyCacheRevision();
 }

--- a/src/kv/config.ts
+++ b/src/kv/config.ts
@@ -1,5 +1,6 @@
 import type { ProxyConfig } from "../types.ts";
 import {
+  AUTH_CACHE_REVISION_KEY,
   CONFIG_KEY,
   DEFAULT_KV_FLUSH_INTERVAL_MS,
   DEFAULT_MODEL_POOL,
@@ -8,7 +9,7 @@ import {
 import { normalizeKvFlushIntervalMs } from "../utils.ts";
 import { normalizeModelPool } from "../models.ts";
 import { state } from "../state.ts";
-import { bumpAuthCacheRevision } from "./revisions.ts";
+import { getNextRevisionValue, recordAuthCacheRevision } from "./revisions.ts";
 
 export function resolveKvFlushIntervalMs(config: ProxyConfig | null): number {
   const ms = config?.kvFlushIntervalMs ?? DEFAULT_KV_FLUSH_INTERVAL_MS;
@@ -129,16 +130,24 @@ export async function kvUpdateConfig(
       return entry.value;
     }
     const validatedConfig = validateProxyConfig(nextConfig);
-    const result = await state.kv
+    let atomic = state.kv
       .atomic()
       .check(entry)
-      .set(CONFIG_KEY, validatedConfig)
-      .commit();
+      .set(CONFIG_KEY, validatedConfig);
+    let nextRevision: number | null = null;
+    const shouldBumpAuthRevision =
+      validatedConfig.proxyPublicAccess !== entry.value.proxyPublicAccess;
+    if (shouldBumpAuthRevision) {
+      const revisionEntry = await state.kv.get<number>(AUTH_CACHE_REVISION_KEY);
+      nextRevision = getNextRevisionValue(revisionEntry);
+      atomic = atomic
+        .check(revisionEntry)
+        .set(AUTH_CACHE_REVISION_KEY, nextRevision);
+    }
+    const result = await atomic.commit();
     if (result.ok) {
       state.cachedConfig = validatedConfig;
-      if (validatedConfig.proxyPublicAccess !== entry.value.proxyPublicAccess) {
-        await bumpAuthCacheRevision();
-      }
+      if (nextRevision !== null) recordAuthCacheRevision(nextRevision);
       return validatedConfig;
     }
     const baseMs = Math.min(10 * 2 ** attempt, 500);

--- a/src/kv/config.ts
+++ b/src/kv/config.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeKvFlushIntervalMs } from "../utils.ts";
 import { normalizeModelPool } from "../models.ts";
 import { state } from "../state.ts";
+import { bumpAuthCacheRevision } from "./revisions.ts";
 
 export function resolveKvFlushIntervalMs(config: ProxyConfig | null): number {
   const ms = config?.kvFlushIntervalMs ?? DEFAULT_KV_FLUSH_INTERVAL_MS;
@@ -135,6 +136,9 @@ export async function kvUpdateConfig(
       .commit();
     if (result.ok) {
       state.cachedConfig = validatedConfig;
+      if (validatedConfig.proxyPublicAccess !== entry.value.proxyPublicAccess) {
+        await bumpAuthCacheRevision();
+      }
       return validatedConfig;
     }
     const baseMs = Math.min(10 * 2 ** attempt, 500);

--- a/src/kv/flush.ts
+++ b/src/kv/flush.ts
@@ -17,6 +17,7 @@ import {
 } from "./config.ts";
 import { kvGetAllKeys } from "./api-keys.ts";
 import { kvGetAllProxyKeys } from "./proxy-keys.ts";
+import { getApiKeyCacheRevision, getAuthCacheRevision } from "./revisions.ts";
 import { metrics } from "../metrics.ts";
 
 export { resolveKvFlushIntervalMs } from "./config.ts";
@@ -183,4 +184,8 @@ export async function bootstrapCache(): Promise<void> {
   const proxyKeys = await kvGetAllProxyKeys();
   state.cachedProxyKeys = new Map(proxyKeys.map((k) => [k.id, k]));
   state.proxyKeyCacheLastLoadedAt = Date.now();
+  state.authCacheRevision = await getAuthCacheRevision();
+  state.authCacheRevisionLastCheckedAt = Date.now();
+  state.apiKeyCacheRevision = await getApiKeyCacheRevision();
+  state.apiKeyCacheRevisionLastCheckedAt = Date.now();
 }

--- a/src/kv/proxy-keys.ts
+++ b/src/kv/proxy-keys.ts
@@ -1,10 +1,14 @@
 import type { ProxyAuthKey } from "../types.ts";
-import { MAX_PROXY_KEYS, PROXY_KEY_PREFIX } from "../constants.ts";
+import {
+  AUTH_CACHE_REVISION_KEY,
+  MAX_PROXY_KEYS,
+  PROXY_KEY_PREFIX,
+} from "../constants.ts";
 import { generateProxyKey } from "../keys.ts";
 import { generateId } from "../utils.ts";
 import { hashProxyKey, isHashedProxyKey } from "../secrets.ts";
 import { state } from "../state.ts";
-import { bumpAuthCacheRevision } from "./revisions.ts";
+import { getNextRevisionValue, recordAuthCacheRevision } from "./revisions.ts";
 
 type LegacyProxyAuthKey = Omit<ProxyAuthKey, "keyHash"> & { key: string };
 
@@ -132,9 +136,18 @@ export async function kvAddProxyKey(
     createdAt: Date.now(),
   };
 
-  await state.kv.set([...PROXY_KEY_PREFIX, id], newKey);
+  const revisionEntry = await state.kv.get<number>(AUTH_CACHE_REVISION_KEY);
+  const revision = getNextRevisionValue(revisionEntry);
+  const result = await state.kv.atomic()
+    .check(revisionEntry)
+    .set([...PROXY_KEY_PREFIX, id], newKey)
+    .set(AUTH_CACHE_REVISION_KEY, revision)
+    .commit();
+  if (!result.ok) {
+    return { success: false, error: "代理密钥保存失败，请重试" };
+  }
   cachedKeys.set(id, newKey);
-  await bumpAuthCacheRevision();
+  recordAuthCacheRevision(revision);
 
   return { success: true, id, key };
 }
@@ -148,9 +161,19 @@ export async function kvDeleteProxyKey(
     return { success: false, error: "密钥不存在" };
   }
 
-  await state.kv.delete(key);
+  const revisionEntry = await state.kv.get<number>(AUTH_CACHE_REVISION_KEY);
+  const revision = getNextRevisionValue(revisionEntry);
+  const deleteResult = await state.kv.atomic()
+    .check(result)
+    .check(revisionEntry)
+    .delete(key)
+    .set(AUTH_CACHE_REVISION_KEY, revision)
+    .commit();
+  if (!deleteResult.ok) {
+    return { success: false, error: "代理密钥删除失败，请重试" };
+  }
   state.cachedProxyKeys?.delete(id);
   state.dirtyProxyKeyIds.delete(id);
-  await bumpAuthCacheRevision();
+  recordAuthCacheRevision(revision);
   return { success: true };
 }

--- a/src/kv/proxy-keys.ts
+++ b/src/kv/proxy-keys.ts
@@ -4,6 +4,7 @@ import { generateProxyKey } from "../keys.ts";
 import { generateId } from "../utils.ts";
 import { hashProxyKey, isHashedProxyKey } from "../secrets.ts";
 import { state } from "../state.ts";
+import { bumpAuthCacheRevision } from "./revisions.ts";
 
 type LegacyProxyAuthKey = Omit<ProxyAuthKey, "keyHash"> & { key: string };
 
@@ -133,6 +134,7 @@ export async function kvAddProxyKey(
 
   await state.kv.set([...PROXY_KEY_PREFIX, id], newKey);
   cachedKeys.set(id, newKey);
+  await bumpAuthCacheRevision();
 
   return { success: true, id, key };
 }
@@ -149,5 +151,6 @@ export async function kvDeleteProxyKey(
   await state.kv.delete(key);
   state.cachedProxyKeys?.delete(id);
   state.dirtyProxyKeyIds.delete(id);
+  await bumpAuthCacheRevision();
   return { success: true };
 }

--- a/src/kv/revisions.ts
+++ b/src/kv/revisions.ts
@@ -7,19 +7,23 @@ import { state } from "../state.ts";
 
 async function getRevision(key: readonly string[]): Promise<number> {
   const entry = await state.kv.get<number>(key);
+  return getRevisionValue(entry);
+}
+
+export function getRevisionValue(entry: Deno.KvEntryMaybe<number>): number {
   return typeof entry.value === "number" && Number.isFinite(entry.value)
     ? entry.value
     : 0;
 }
 
+export function getNextRevisionValue(entry: Deno.KvEntryMaybe<number>): number {
+  return Math.max(Date.now(), getRevisionValue(entry) + 1);
+}
+
 async function bumpRevision(key: readonly string[]): Promise<number> {
   for (let attempt = 0; attempt < KV_ATOMIC_MAX_RETRIES; attempt++) {
     const entry = await state.kv.get<number>(key);
-    const current = typeof entry.value === "number" &&
-        Number.isFinite(entry.value)
-      ? entry.value
-      : 0;
-    const next = Math.max(Date.now(), current + 1);
+    const next = getNextRevisionValue(entry);
     const result = await state.kv.atomic()
       .check(entry)
       .set(key, next)
@@ -34,8 +38,7 @@ export function getAuthCacheRevision(): Promise<number> {
 }
 
 export async function bumpAuthCacheRevision(): Promise<number> {
-  state.authCacheRevision = await bumpRevision(AUTH_CACHE_REVISION_KEY);
-  state.authCacheRevisionLastCheckedAt = Date.now();
+  recordAuthCacheRevision(await bumpRevision(AUTH_CACHE_REVISION_KEY));
   return state.authCacheRevision;
 }
 
@@ -43,8 +46,17 @@ export function getApiKeyCacheRevision(): Promise<number> {
   return getRevision(API_KEY_CACHE_REVISION_KEY);
 }
 
+export function recordAuthCacheRevision(revision: number): void {
+  state.authCacheRevision = revision;
+  state.authCacheRevisionLastCheckedAt = Date.now();
+}
+
 export async function bumpApiKeyCacheRevision(): Promise<number> {
-  state.apiKeyCacheRevision = await bumpRevision(API_KEY_CACHE_REVISION_KEY);
-  state.apiKeyCacheRevisionLastCheckedAt = Date.now();
+  recordApiKeyCacheRevision(await bumpRevision(API_KEY_CACHE_REVISION_KEY));
   return state.apiKeyCacheRevision;
+}
+
+export function recordApiKeyCacheRevision(revision: number): void {
+  state.apiKeyCacheRevision = revision;
+  state.apiKeyCacheRevisionLastCheckedAt = Date.now();
 }

--- a/src/kv/revisions.ts
+++ b/src/kv/revisions.ts
@@ -1,0 +1,50 @@
+import {
+  API_KEY_CACHE_REVISION_KEY,
+  AUTH_CACHE_REVISION_KEY,
+  KV_ATOMIC_MAX_RETRIES,
+} from "../constants.ts";
+import { state } from "../state.ts";
+
+async function getRevision(key: readonly string[]): Promise<number> {
+  const entry = await state.kv.get<number>(key);
+  return typeof entry.value === "number" && Number.isFinite(entry.value)
+    ? entry.value
+    : 0;
+}
+
+async function bumpRevision(key: readonly string[]): Promise<number> {
+  for (let attempt = 0; attempt < KV_ATOMIC_MAX_RETRIES; attempt++) {
+    const entry = await state.kv.get<number>(key);
+    const current = typeof entry.value === "number" &&
+        Number.isFinite(entry.value)
+      ? entry.value
+      : 0;
+    const next = Math.max(Date.now(), current + 1);
+    const result = await state.kv.atomic()
+      .check(entry)
+      .set(key, next)
+      .commit();
+    if (result.ok) return next;
+  }
+  throw new Error("KV revision update failed after retries");
+}
+
+export function getAuthCacheRevision(): Promise<number> {
+  return getRevision(AUTH_CACHE_REVISION_KEY);
+}
+
+export async function bumpAuthCacheRevision(): Promise<number> {
+  state.authCacheRevision = await bumpRevision(AUTH_CACHE_REVISION_KEY);
+  state.authCacheRevisionLastCheckedAt = Date.now();
+  return state.authCacheRevision;
+}
+
+export function getApiKeyCacheRevision(): Promise<number> {
+  return getRevision(API_KEY_CACHE_REVISION_KEY);
+}
+
+export async function bumpApiKeyCacheRevision(): Promise<number> {
+  state.apiKeyCacheRevision = await bumpRevision(API_KEY_CACHE_REVISION_KEY);
+  state.apiKeyCacheRevisionLastCheckedAt = Date.now();
+  return state.apiKeyCacheRevision;
+}

--- a/src/services/proxy.ts
+++ b/src/services/proxy.ts
@@ -13,6 +13,7 @@ import {
   getNextApiKeyFast,
   markKeyCooldownFrom429,
   markKeyInvalid,
+  refreshApiKeyCacheIfChanged,
 } from "../api-keys.ts";
 import {
   getNextModelFast,
@@ -119,6 +120,7 @@ async function discardBoundedUpstreamErrorBody(
 export async function forwardChatCompletion(
   requestBody: Record<string, unknown>,
 ): Promise<ProxyResult> {
+  await refreshApiKeyCacheIfChanged();
   let apiKeyData = getNextApiKeyFast(Date.now());
   if (!apiKeyData) {
     await kvMergeAllApiKeysIntoCache();

--- a/src/state.ts
+++ b/src/state.ts
@@ -41,6 +41,11 @@ export class AppState {
     null;
   proxyKeyCacheLastLoadedAt = 0;
   dirtyProxyKeyIds = new Set<string>();
+  authCacheRevision = 0;
+  authCacheRevisionLastCheckedAt = 0;
+
+  apiKeyCacheRevision = 0;
+  apiKeyCacheRevisionLastCheckedAt = 0;
 
   addPendingTotalRequests(delta: number): void {
     if (!Number.isFinite(delta) || delta <= 0) return;


### PR DESCRIPTION
## Summary

Fixes #130.

- add monotonic KV revision counters for auth and API-key caches so revocations propagate across isolates
- refresh proxy auth/public-access config and upstream API-key selection when revisions change
- store admin session tokens under keyed digests instead of plaintext token key material
- add integration regressions for token storage, proxy-key revocation, public-access revocation, and stale API-key eviction

## Validation

- [x] `deno task check`
- [x] `deno task lint`
- [x] `deno task fmt:check`
- [x] `deno task test:unit`
- [x] `deno task docstring:coverage`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 实现缓存修订号机制，自动追踪认证和API密钥缓存变化
  * 添加缓存自动刷新功能，确保权限检查和密钥使用始终基于最新配置

* **Security**
  * 改进管理员令牌存储方式，采用哈希存储提升安全性

* **Tests**
  * 新增多条集成测试用例，覆盖令牌存储、缓存刷新和权限验证场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->