### PR TITLE
fix(security): tighten revision refresh retries

### DIFF
--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -13,6 +13,7 @@ import { metrics } from "../metrics.ts";
 import {
   ADMIN_CORS_HEADERS,
   ADMIN_TOKEN_PREFIX,
+  API_KEY_CACHE_REVISION_KEY,
   API_KEY_PREFIX,
   CEREBRAS_API_URL,
   CORS_HEADERS,
@@ -234,6 +235,8 @@ Deno.test("integration: admin session tokens are stored as keyed digests", async
   const token = await createAdminToken();
   const plaintextEntry = await kv.get([...ADMIN_TOKEN_PREFIX, token]);
   assertEquals(plaintextEntry.value, null);
+  await kv.set([...ADMIN_TOKEN_PREFIX, "legacy-token"], Date.now() + 60_000);
+  assertEquals(await verifyAdminToken("legacy-token"), false);
 
   const digestEntry = await kv.get([
     ...ADMIN_TOKEN_PREFIX,
@@ -1004,6 +1007,52 @@ Deno.test("integration: public access cache refreshes after config revision", as
   kv.close();
 });
 
+Deno.test("integration: auth revision refresh retries after cache failure", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  const token = await enableProxyPublicAccess(handler);
+
+  await handler(
+    makeReq("PATCH", "/api/config", {
+      headers: { "X-Admin-Token": token },
+      body: { proxyPublicAccess: false },
+    }),
+  );
+  state.cachedConfig!.proxyPublicAccess = true;
+  state.proxyKeyCacheLastLoadedAt = 0;
+  state.authCacheRevision = 0;
+  state.authCacheRevisionLastCheckedAt = 0;
+
+  const originalList = state.kv.list.bind(state.kv);
+  let failed = false;
+  state.kv.list = ((
+    selector: Deno.KvListSelector,
+    options?: Deno.KvListOptions,
+  ) => {
+    if (!failed) {
+      failed = true;
+      throw new Error("transient proxy key list failure");
+    }
+    return originalList(selector, options);
+  }) as typeof state.kv.list;
+
+  await assertRejects(
+    () => isProxyAuthorized(makeReq("POST", "/v1/chat/completions")),
+    Error,
+    "transient proxy key list failure",
+  );
+  assertEquals(state.authCacheRevision, 0);
+  assertEquals(state.authCacheRevisionLastCheckedAt, 0);
+  state.kv.list = originalList;
+
+  const auth = await isProxyAuthorized(
+    makeReq("POST", "/v1/chat/completions"),
+  );
+  assertEquals(auth.authorized, false);
+
+  kv.close();
+});
+
 Deno.test("integration: proxy invalid tokens do not repeatedly reload empty cache", async () => {
   const kv = await setupKv();
   const handler = buildHandler();
@@ -1268,6 +1317,8 @@ Deno.test("integration: upstream 401 invalidation does not persist plaintext API
       JSON.stringify(persisted).includes("sk-invalidated-secret"),
       false,
     );
+    const revisionEntry = await kv.get<number>(API_KEY_CACHE_REVISION_KEY);
+    assertEquals(typeof revisionEntry.value, "number");
   } finally {
     restoreFetch();
     kv.close();
@@ -1280,10 +1331,7 @@ Deno.test("integration: API key cache evicts stale deleted keys after revision",
   const [apiKeyId] = state.cachedActiveKeyIds;
 
   await kv.delete([...API_KEY_PREFIX, apiKeyId]);
-  await kv.set(
-    ["cerebras-proxy", "meta", "api_key_cache_revision"],
-    Date.now(),
-  );
+  await kv.set(API_KEY_CACHE_REVISION_KEY, Date.now());
   state.apiKeyCacheRevision = 0;
   state.apiKeyCacheRevisionLastCheckedAt = 0;
   await refreshApiKeyCacheIfChanged();
@@ -1300,10 +1348,7 @@ Deno.test("integration: API key revision refresh retries after merge failure", a
   const [apiKeyId] = state.cachedActiveKeyIds;
 
   await kv.delete([...API_KEY_PREFIX, apiKeyId]);
-  await kv.set(
-    ["cerebras-proxy", "meta", "api_key_cache_revision"],
-    Date.now(),
-  );
+  await kv.set(API_KEY_CACHE_REVISION_KEY, Date.now());
   state.apiKeyCacheRevision = 0;
   state.apiKeyCacheRevisionLastCheckedAt = 0;
 
@@ -1327,7 +1372,6 @@ Deno.test("integration: API key revision refresh retries after merge failure", a
   );
   assertEquals(state.apiKeyCacheRevision, 0);
   state.kv.list = originalList;
-  state.apiKeyCacheRevisionLastCheckedAt = 0;
 
   await refreshApiKeyCacheIfChanged();
   assertEquals(state.cachedKeysById.has(apiKeyId), false);

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -1011,21 +1011,24 @@ Deno.test("integration: public access refreshes and retries after cache failures
     return originalList(selector, options);
   }) as typeof state.kv.list;
 
-  await assertRejects(
-    () => isProxyAuthorized(makeReq("POST", "/v1/chat/completions")),
-    Error,
-    "transient proxy key list failure",
-  );
-  assertEquals(state.authCacheRevision, 0);
-  assertEquals(state.authCacheRevisionLastCheckedAt, 0);
-  state.kv.list = originalList;
+  try {
+    await assertRejects(
+      () => isProxyAuthorized(makeReq("POST", "/v1/chat/completions")),
+      Error,
+      "transient proxy key list failure",
+    );
+    assertEquals(state.authCacheRevision, 0);
+    assertEquals(state.authCacheRevisionLastCheckedAt, 0);
+    state.kv.list = originalList;
 
-  const auth = await isProxyAuthorized(
-    makeReq("POST", "/v1/chat/completions"),
-  );
-  assertEquals(auth.authorized, false);
-
-  kv.close();
+    const auth = await isProxyAuthorized(
+      makeReq("POST", "/v1/chat/completions"),
+    );
+    assertEquals(auth.authorized, false);
+  } finally {
+    state.kv.list = originalList;
+    kv.close();
+  }
 });
 
 Deno.test("integration: proxy invalid tokens do not repeatedly reload empty cache", async () => {

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -982,32 +982,7 @@ Deno.test("integration: proxy explicit public mode allows requests without keys"
   kv.close();
 });
 
-Deno.test("integration: public access cache refreshes after config revision", async () => {
-  const kv = await setupKv();
-  const handler = buildHandler();
-  const token = await enableProxyPublicAccess(handler);
-
-  state.cachedConfig!.proxyPublicAccess = true;
-  await handler(
-    makeReq("PATCH", "/api/config", {
-      headers: { "X-Admin-Token": token },
-      body: { proxyPublicAccess: false },
-    }),
-  );
-  state.cachedConfig!.proxyPublicAccess = true;
-  state.proxyKeyCacheLastLoadedAt = 0;
-  state.authCacheRevision = 0;
-  state.authCacheRevisionLastCheckedAt = 0;
-
-  const auth = await isProxyAuthorized(
-    makeReq("POST", "/v1/chat/completions"),
-  );
-  assertEquals(auth.authorized, false);
-
-  kv.close();
-});
-
-Deno.test("integration: auth revision refresh retries after cache failure", async () => {
+Deno.test("integration: public access refreshes and retries after cache failures", async () => {
   const kv = await setupKv();
   const handler = buildHandler();
   const token = await enableProxyPublicAccess(handler);

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -1,10 +1,15 @@
 import {
+  API_KEY_CACHE_REVISION_KEY,
   API_KEY_PREFIX,
   PROXY_KEY_AUTH_REFRESH_INTERVAL_MS,
 } from "./constants.ts";
 import { toPersistedApiKey } from "./api-key-record.ts";
 import { state } from "./state.ts";
-import { getApiKeyCacheRevision } from "./kv/revisions.ts";
+import {
+  getApiKeyCacheRevision,
+  getNextRevisionValue,
+  recordApiKeyCacheRevision,
+} from "./kv/revisions.ts";
 import { kvMergeAllApiKeysIntoCache } from "./kv/api-keys.ts";
 
 export function rebuildActiveKeyIds(): void {
@@ -57,6 +62,19 @@ export function getNextApiKeyFast(
 }
 
 export async function refreshApiKeyCacheIfChanged(): Promise<void> {
+  if (state.apiKeyCacheRevisionRefreshInFlight) {
+    return await state.apiKeyCacheRevisionRefreshInFlight;
+  }
+  const refresh = refreshApiKeyCacheRevision();
+  state.apiKeyCacheRevisionRefreshInFlight = refresh;
+  try {
+    await refresh;
+  } finally {
+    state.apiKeyCacheRevisionRefreshInFlight = null;
+  }
+}
+
+async function refreshApiKeyCacheRevision(): Promise<void> {
   const now = Date.now();
   if (
     now - state.apiKeyCacheRevisionLastCheckedAt <
@@ -65,10 +83,12 @@ export async function refreshApiKeyCacheIfChanged(): Promise<void> {
     return;
   }
   const revision = await getApiKeyCacheRevision();
-  state.apiKeyCacheRevisionLastCheckedAt = now;
-  if (revision === state.apiKeyCacheRevision) return;
+  if (revision === state.apiKeyCacheRevision) {
+    state.apiKeyCacheRevisionLastCheckedAt = now;
+    return;
+  }
   await kvMergeAllApiKeysIntoCache();
-  state.apiKeyCacheRevision = revision;
+  recordApiKeyCacheRevision(revision);
 }
 
 export function markKeyCooldownFrom429(id: string, response: Response): void {
@@ -88,7 +108,21 @@ export async function markKeyInvalid(id: string): Promise<void> {
   state.dirtyKeyIds.delete(id);
   rebuildActiveKeyIds();
   try {
-    await state.kv.set([...API_KEY_PREFIX, id], toPersistedApiKey(keyEntry));
+    const key = [...API_KEY_PREFIX, id];
+    const entry = await state.kv.get(key);
+    if (!entry.value) return;
+    const revisionEntry = await state.kv.get<number>(
+      API_KEY_CACHE_REVISION_KEY,
+    );
+    const revision = getNextRevisionValue(revisionEntry);
+    const result = await state.kv.atomic()
+      .check(entry)
+      .check(revisionEntry)
+      .set(key, toPersistedApiKey(keyEntry))
+      .set(API_KEY_CACHE_REVISION_KEY, revision)
+      .commit();
+    if (!result.ok) throw new Error("API key invalidation write conflict");
+    recordApiKeyCacheRevision(revision);
   } catch (error) {
     state.dirtyKeyIds.add(id);
     console.error("[KV] markKeyInvalid immediate write failed:", error);

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -109,11 +109,11 @@ export async function markKeyInvalid(id: string): Promise<void> {
   rebuildActiveKeyIds();
   try {
     const key = [...API_KEY_PREFIX, id];
-    const entry = await state.kv.get(key);
+    const [entry, revisionEntry] = await Promise.all([
+      state.kv.get(key),
+      state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
+    ]);
     if (!entry.value) return;
-    const revisionEntry = await state.kv.get<number>(
-      API_KEY_CACHE_REVISION_KEY,
-    );
     const revision = getNextRevisionValue(revisionEntry);
     const result = await state.kv.atomic()
       .check(entry)

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -125,6 +125,19 @@ async function refreshProxyKeyCache(): Promise<Map<string, ProxyAuthKey>> {
 }
 
 async function refreshAuthCacheIfChanged(): Promise<void> {
+  if (state.authCacheRevisionRefreshInFlight) {
+    return await state.authCacheRevisionRefreshInFlight;
+  }
+  const refresh = refreshAuthCacheRevision();
+  state.authCacheRevisionRefreshInFlight = refresh;
+  try {
+    await refresh;
+  } finally {
+    state.authCacheRevisionRefreshInFlight = null;
+  }
+}
+
+async function refreshAuthCacheRevision(): Promise<void> {
   const now = Date.now();
   if (
     now - state.authCacheRevisionLastCheckedAt <
@@ -133,11 +146,14 @@ async function refreshAuthCacheIfChanged(): Promise<void> {
     return;
   }
   const revision = await getAuthCacheRevision();
-  state.authCacheRevisionLastCheckedAt = now;
-  if (revision === state.authCacheRevision) return;
+  if (revision === state.authCacheRevision) {
+    state.authCacheRevisionLastCheckedAt = now;
+    return;
+  }
   state.cachedConfig = await kvGetConfig();
   await refreshProxyKeyCache();
   state.authCacheRevision = revision;
+  state.authCacheRevisionLastCheckedAt = Date.now();
 }
 
 function shouldRefreshProxyKeyCache(): boolean {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -150,8 +150,11 @@ async function refreshAuthCacheRevision(): Promise<void> {
     state.authCacheRevisionLastCheckedAt = now;
     return;
   }
-  state.cachedConfig = await kvGetConfig();
-  await refreshProxyKeyCache();
+  const [config] = await Promise.all([
+    kvGetConfig(),
+    refreshProxyKeyCache(),
+  ]);
+  state.cachedConfig = config;
   state.authCacheRevision = revision;
   state.authCacheRevisionLastCheckedAt = Date.now();
 }

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -160,8 +160,13 @@ export async function kvAddKey(
   };
 
   const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
+  const idEntry = await state.kv.get([...API_KEY_PREFIX, id]);
+  if (idEntry.value !== null) {
+    return { success: false, error: "密钥保存冲突，请重试" };
+  }
   const revision = getNextRevisionValue(revisionEntry);
   const result = await state.kv.atomic()
+    .check(idEntry)
     .check(revisionEntry)
     .set([...API_KEY_PREFIX, id], toPersistedApiKey(newKey))
     .set(API_KEY_CACHE_REVISION_KEY, revision)

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -159,8 +159,10 @@ export async function kvAddKey(
     createdAt,
   };
 
-  const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
-  const idEntry = await state.kv.get([...API_KEY_PREFIX, id]);
+  const [revisionEntry, idEntry] = await Promise.all([
+    state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
+    state.kv.get([...API_KEY_PREFIX, id]),
+  ]);
   if (idEntry.value !== null) {
     return { success: false, error: "密钥保存冲突，请重试" };
   }

--- a/src/kv/revisions.ts
+++ b/src/kv/revisions.ts
@@ -1,7 +1,6 @@
 import {
   API_KEY_CACHE_REVISION_KEY,
   AUTH_CACHE_REVISION_KEY,
-  KV_ATOMIC_MAX_RETRIES,
 } from "../constants.ts";
 import { state } from "../state.ts";
 
@@ -20,26 +19,8 @@ export function getNextRevisionValue(entry: Deno.KvEntryMaybe<number>): number {
   return Math.max(Date.now(), getRevisionValue(entry) + 1);
 }
 
-async function bumpRevision(key: readonly string[]): Promise<number> {
-  for (let attempt = 0; attempt < KV_ATOMIC_MAX_RETRIES; attempt++) {
-    const entry = await state.kv.get<number>(key);
-    const next = getNextRevisionValue(entry);
-    const result = await state.kv.atomic()
-      .check(entry)
-      .set(key, next)
-      .commit();
-    if (result.ok) return next;
-  }
-  throw new Error("KV revision update failed after retries");
-}
-
 export function getAuthCacheRevision(): Promise<number> {
   return getRevision(AUTH_CACHE_REVISION_KEY);
-}
-
-export async function bumpAuthCacheRevision(): Promise<number> {
-  recordAuthCacheRevision(await bumpRevision(AUTH_CACHE_REVISION_KEY));
-  return state.authCacheRevision;
 }
 
 export function getApiKeyCacheRevision(): Promise<number> {
@@ -49,11 +30,6 @@ export function getApiKeyCacheRevision(): Promise<number> {
 export function recordAuthCacheRevision(revision: number): void {
   state.authCacheRevision = revision;
   state.authCacheRevisionLastCheckedAt = Date.now();
-}
-
-export async function bumpApiKeyCacheRevision(): Promise<number> {
-  recordApiKeyCacheRevision(await bumpRevision(API_KEY_CACHE_REVISION_KEY));
-  return state.apiKeyCacheRevision;
 }
 
 export function recordApiKeyCacheRevision(revision: number): void {

--- a/src/state.ts
+++ b/src/state.ts
@@ -43,9 +43,11 @@ export class AppState {
   dirtyProxyKeyIds = new Set<string>();
   authCacheRevision = 0;
   authCacheRevisionLastCheckedAt = 0;
+  authCacheRevisionRefreshInFlight: Promise<void> | null = null;
 
   apiKeyCacheRevision = 0;
   apiKeyCacheRevisionLastCheckedAt = 0;
+  apiKeyCacheRevisionRefreshInFlight: Promise<void> | null = null;
 
   addPendingTotalRequests(delta: number): void {
     if (!Number.isFinite(delta) || delta <= 0) return;


### PR DESCRIPTION
## Summary
- Keeps auth/API-key revision refresh retries immediate after transient cache-load failures by only updating last-check timestamps after unchanged or successful refresh paths.
- Deduplicates concurrent revision checks and bumps the API-key cache revision when upstream 401 handling invalidates a key.
- CAS-checks generated API-key IDs before insert, removes now-dead revision bump helpers, and adds regression coverage for the review feedback.

## Notes
- Follow-up to #131 / #130 because #131 merged before this final review-feedback commit reached `main`.
- The admin session token digest-key migration from #131 invalidates existing admin sessions; users should log in again after deploying that change.

## Validation
- `deno task check`
- `deno task lint`
- `deno task fmt:check`
- `deno task test:unit` — 136 passed / 0 failed
- `deno task docstring:coverage` — 100% (18/18)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进缓存刷新机制，防止并发重复刷新导致的性能问题。
  * 增强API密钥和认证缓存的一致性，采用原子事务防止并发冲突。
  * 优化缓存修订版本管理，提高故障重试的可靠性。

* **测试**
  * 扩展集成测试覆盖，验证缓存故障恢复和遗留令牌处理场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->