### PR TITLE
fix(proxy): circuit breaker ignores 4xx instead of resetting failure count

### DIFF
--- a/src/__tests__/proxy-circuit_test.ts
+++ b/src/__tests__/proxy-circuit_test.ts
@@ -140,3 +140,113 @@ Deno.test("proxy circuit: ignores key errors", async () => {
     kv.close();
   }
 });
+
+Deno.test(
+  "proxy circuit: still opens when 5xx alternates with 4xx (regression for #137)",
+  async () => {
+    const kv = await setupKv();
+    const handler = createHandler(createRouter());
+    state.cachedConfig = { ...state.cachedConfig!, proxyPublicAccess: true };
+
+    // Need enough keys so 429-driven cooldown doesn't drain the pool
+    // before the alternating sequence completes.
+    for (let i = 0; i < 5; i++) {
+      await addActiveApiKey(`sk-upstream-test-${i}`);
+    }
+
+    let fetchCount = 0;
+    const restoreFetch = installUpstreamResponse(() => {
+      fetchCount += 1;
+      // Alternate: 503, 429, 503, 429, 503, ...
+      const status = fetchCount % 2 === 1 ? 503 : 429;
+      return new Response(JSON.stringify({ error: "x" }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    try {
+      // 503, 429, 503, 429, 503 → 3 distinct upstream 5xx → circuit opens.
+      // Before the fix, 429 would call recordUpstreamSuccess() and reset
+      // failureCount to 0, so the breaker never reached the threshold.
+      const expected = [503, 429, 503, 429, 503];
+      for (const wantUpstream of expected) {
+        const res = await handler(
+          makeReq({ messages: [{ role: "user", content: "hi" }] }),
+        );
+        // Proxy sanitizes upstream errors to its own status code.
+        // For 503 upstream → 503 client; for 429 upstream → 429 client.
+        assertEquals(res.status, wantUpstream);
+        await res.body?.cancel();
+      }
+      assertEquals(fetchCount, expected.length);
+
+      // Circuit must now be open: next request is rejected without hitting
+      // upstream.
+      const blocked = await handler(
+        makeReq({ messages: [{ role: "user", content: "hi" }] }),
+      );
+      assertEquals(blocked.status, 503);
+      assertEquals(blocked.headers.has("Retry-After"), true);
+      const body = await blocked.json();
+      assertEquals(body.error.code, "upstream_circuit_open");
+      // fetchCount didn't grow → upstream wasn't called.
+      assertEquals(fetchCount, expected.length);
+    } finally {
+      setLogSinkForTests(null);
+      restoreFetch();
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "proxy circuit: 2xx response closes the circuit (sanity check after #137)",
+  async () => {
+    const kv = await setupKv();
+    const handler = createHandler(createRouter());
+    state.cachedConfig = { ...state.cachedConfig!, proxyPublicAccess: true };
+    await addActiveApiKey("sk-upstream-test");
+
+    let fetchCount = 0;
+    const restoreFetch = installUpstreamResponse(() => {
+      fetchCount += 1;
+      // Two failures then a success: failureCount should be reset to 0.
+      if (fetchCount <= 2) {
+        return new Response(JSON.stringify({ error: "x" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ id: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    try {
+      // Two 5xx: failureCount=2, breaker still closed (threshold is 3).
+      for (let i = 0; i < 2; i++) {
+        const res = await handler(
+          makeReq({ messages: [{ role: "user", content: "hi" }] }),
+        );
+        assertEquals(res.status, 503);
+        await res.body?.cancel();
+      }
+      assertEquals(state.upstreamCircuitFailureCount, 2);
+
+      // One 2xx: failureCount must reset to 0.
+      const ok = await handler(
+        makeReq({ messages: [{ role: "user", content: "hi" }] }),
+      );
+      assertEquals(ok.status, 200);
+      await ok.body?.cancel();
+      assertEquals(state.upstreamCircuitFailureCount, 0);
+      assertEquals(state.upstreamCircuitOpenedUntil, 0);
+    } finally {
+      setLogSinkForTests(null);
+      restoreFetch();
+      kv.close();
+    }
+  },
+);

--- a/src/services/proxy.ts
+++ b/src/services/proxy.ts
@@ -213,9 +213,14 @@ export async function forwardChatCompletion(
     if (apiResponse.status >= 500) {
       recordUpstreamFailure();
       metrics.inc("upstream_responses_total", "5xx");
-    } else {
+    } else if (apiResponse.ok) {
       recordUpstreamSuccess();
     }
+    // 4xx responses (401/403/404/429/etc) are ignored by the circuit
+    // breaker: they aren't real upstream outages, and resetting the
+    // failure counter on every 4xx would let intermittent client errors
+    // (especially 429) mask underlying 5xx and keep the breaker from
+    // ever opening under realistic mixed traffic. See issue #137.
 
     if (apiResponse.status === 404) {
       const bodyRead = await readBoundedBodyText(apiResponse.body);

--- a/src/services/proxy.ts
+++ b/src/services/proxy.ts
@@ -125,6 +125,24 @@ async function discardBoundedUpstreamErrorBody(
   await readBoundedBodyText(response.body);
 }
 
+/**
+ * Classifies an upstream response for the circuit breaker:
+ * - 5xx: counts as a failure and bumps the breaker.
+ * - 2xx: counts as a success and closes the breaker.
+ * - 4xx: ignored — it's a client/upstream-classification error, not an
+ *   outage. Treating 4xx as success would let intermittent 429s reset the
+ *   failure counter and prevent the breaker from ever opening under mixed
+ *   5xx + 429 traffic. See issue #137.
+ */
+function recordCircuitOutcome(status: number): void {
+  if (status >= 500) {
+    recordUpstreamFailure();
+    metrics.inc("upstream_responses_total", "5xx");
+  } else if (status >= 200 && status < 300) {
+    recordUpstreamSuccess();
+  }
+}
+
 export async function forwardChatCompletion(
   requestBody: Record<string, unknown>,
   context: ProxyLogContext = {},
@@ -210,17 +228,7 @@ export async function forwardChatCompletion(
       return { kind: "error", message: "上游请求失败", status: 502 };
     }
 
-    if (apiResponse.status >= 500) {
-      recordUpstreamFailure();
-      metrics.inc("upstream_responses_total", "5xx");
-    } else if (apiResponse.ok) {
-      recordUpstreamSuccess();
-    }
-    // 4xx responses (401/403/404/429/etc) are ignored by the circuit
-    // breaker: they aren't real upstream outages, and resetting the
-    // failure counter on every 4xx would let intermittent client errors
-    // (especially 429) mask underlying 5xx and keep the breaker from
-    // ever opening under realistic mixed traffic. See issue #137.
+    recordCircuitOutcome(apiResponse.status);
 
     if (apiResponse.status === 404) {
       const bodyRead = await readBoundedBodyText(apiResponse.body);


### PR DESCRIPTION
Closes #137.

## 问题

`src/services/proxy.ts` 的熔断器记录逻辑把所有非 5xx 响应都当作成功：

```ts
if (apiResponse.status >= 500) {
  recordUpstreamFailure();
} else {
  recordUpstreamSuccess();   // 4xx 也走这里 → failureCount 归零
}
```

`recordUpstreamSuccess()` 直接把 `state.upstreamCircuitFailureCount` 清零。当上游 5xx 与 4xx（典型如 429）交替出现时，`failureCount` 永远在 0/1/2 间震荡，无法到达 `UPSTREAM_CIRCUIT_FAILURE_THRESHOLD = 3`，**熔断器永远不会打开**。

## 修复

只在确认上游成功（`apiResponse.ok === true`，即 2xx）的分支调用 `recordUpstreamSuccess()`，4xx 响应被熔断器忽略——既不递增也不重置失败计数。

```ts
if (apiResponse.status >= 500) {
  recordUpstreamFailure();
  metrics.inc("upstream_responses_total", "5xx");
} else if (apiResponse.ok) {
  recordUpstreamSuccess();
}
// 4xx (401/403/404/429/etc) ignored.
```

## 回归测试

新增两条测试：

- **`proxy circuit: still opens when 5xx alternates with 4xx (regression for #137)`**
  发送 `503, 429, 503, 429, 503` 五个请求，断言第三个 503 后熔断器打开，下一次请求被拦截返回 `upstream_circuit_open`，未到达上游。
- **`proxy circuit: 2xx response closes the circuit (sanity check after #137)`**
  两个 503 让 `failureCount = 2`，紧接着一个 200 必须把 `failureCount` 重置为 0，验证 2xx 的关闭逻辑没坏。

现有 `proxy circuit: opens after repeated 5xx responses` 与 `proxy circuit: ignores key errors` 仍然通过。

## 验证

```
deno task fmt:check    ✓
deno task lint         ✓
deno task check        ✓
deno task test:ci      ✓ 155 passed
```

预提交钩子（`AGENTS check / large-files / tech-debt / unused-deps / check`）也都通过。

## 与 issue 的关系

直接闭合 #137。#138（KV 故障热循环）和 #139（多实例重复 key）保持独立 issue 不在本 PR 范围内。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了上游熔断判断与计数逻辑：在 5xx 与 4xx/429 混合出现时能正确累计失败、打开熔断并在打开后拦截请求；收到成功响应时能按规则重置失败计数。

* **Tests**
  * 新增测试覆盖混合错误场景和熔断恢复，验证熔断打开、拦截行为及成功后计数重置。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->