### PR TITLE
fix(types): timer id types compatible with Deno 2.8 / TS 6.0

### DIFF
--- a/src/proxy-validation.ts
+++ b/src/proxy-validation.ts
@@ -70,7 +70,7 @@ export async function readBoundedTextForTests(
         return { ok: false, status: 408, message: "请求体读取超时" };
       }
       const read = reader.read();
-      let timerId: number | undefined;
+      let timerId: ReturnType<typeof setTimeout> | undefined;
       const timeout = new Promise<"timeout">((resolve) => {
         timerId = setTimeout(
           () => resolve("timeout"),

--- a/src/services/proxy.ts
+++ b/src/services/proxy.ts
@@ -80,7 +80,7 @@ async function readBoundedBodyText(
 
   const chunks: Uint8Array[] = [];
   let total = 0;
-  let timerId: number | undefined;
+  let timerId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<"timeout">((resolve) => {
     timerId = setTimeout(
       () => resolve("timeout"),

--- a/src/state.ts
+++ b/src/state.ts
@@ -28,7 +28,7 @@ export class AppState {
   dirtyKeyIds = new Set<string>();
 
   flushInProgress = false;
-  kvFlushTimerId: number | null = null;
+  kvFlushTimerId: ReturnType<typeof setInterval> | null = null;
   kvFlushIntervalMsEffective = DEFAULT_KV_FLUSH_INTERVAL_MS;
   pendingTotalRequests = 0;
 

--- a/src/stream-limits.ts
+++ b/src/stream-limits.ts
@@ -148,8 +148,8 @@ export function boundProxyResponseBody(
   const reader = body.getReader();
   let totalBytes = 0;
   let finished = false;
-  let idleTimer: number | undefined;
-  let totalTimer: number | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let totalTimer: ReturnType<typeof setTimeout> | undefined;
   let releasePromise: Promise<void> | null = null;
 
   function scheduleIdle(


### PR DESCRIPTION
## 问题

Deno 2.8 / TypeScript 6.0 把 `setTimeout` / `setInterval` 的返回类型从 `number` 改成了一个 `Timeout` 类（带 `unref()` / `ref()` 等 Node-style API）。

```
TS2322 [ERROR]: Type 'Timeout' is not assignable to type 'number'.
```

5 处赋值给 `number | null|undefined` 字段/变量的位置全部 type check 失败：

- `src/state.ts:31` — `kvFlushTimerId: number | null = null;`
- `src/kv/flush.ts:35` — 上一行字段的赋值点
- `src/proxy-validation.ts:72` — `let timerId: number | undefined`
- `src/services/proxy.ts:82` — `let timerId: number | undefined`
- `src/stream-limits.ts:151-152` — `let idleTimer / totalTimer: number | undefined`

CI 用 `denoland/setup-deno@v1` + `deno-version: v2.x` 拿的是 latest stable，今天升级到 2.8 后 main 自身已连续 3 个 commit 失败：

```
26496050198  feat(auth): SETUP_TOKEN-guarded admin password reset
26494796071  fix(kv): avoid CAS conflict on every kvGetConfig
26492107998  ci: sync lovingfish fork
```

所有打开 PR 的 `quality` job 也都因此变红，包括正在跟 #137 走 review 流程的 #141。

## 修复

把所有保存 timer id 的字段/变量类型从 `number` 改成 `ReturnType<typeof setTimeout>`（或 `setInterval` 的版本，对应 `setInterval` 用法）。这两种返回类型在 Deno 2.8 实际是同一个 `Timeout` 类，且 `clearTimeout` / `clearInterval` 都能接受，运行时行为完全不变。这一改也能向前兼容 Deno < 2.8（在那里 `ReturnType<typeof setTimeout>` 就是 `number`）。

## 验证

本地用 Deno 2.8.0 跑：

```
deno task fmt:check     ✓
deno task lint          ✓
deno task naming:check  ✓
deno task complexity:check  ✓
deno task module-boundaries:check  ✓
deno task large-files:check  ✓
deno task tech-debt:check    ✓
deno task duplicate-code:check  ✓
deno task unused-deps:check  ✓
deno task openapi:check ✓
deno task check         ✓
deno task test:ci       ✓ 153 passed
```

## 范围

只触类型回归，不改任何运行时行为；不夹带其他改动。
