### PR TITLE
fix(api-keys): add value-digest secondary index to block cross-instance duplicates

### DIFF
--- a/src/__tests__/api-key-duplicate_test.ts
+++ b/src/__tests__/api-key-duplicate_test.ts
@@ -1,0 +1,299 @@
+/**
+ * Regression tests for issue #139: kvAddKey must reject same-value
+ * duplicates even when the in-memory cache is stale (multi-instance
+ * deploy / cold-start window). The detection relies on a sha256(value)
+ * → id secondary index, which kvBackfillApiKeyValueIndex backfills for
+ * records persisted before the index existed.
+ */
+
+import { assertEquals } from "@std/assert";
+import { API_KEY_PREFIX, API_KEY_VALUE_INDEX_PREFIX } from "../constants.ts";
+import { sha256Hex } from "../crypto.ts";
+import { encryptApiKey } from "../secrets.ts";
+import { kvAddKey, kvDeleteKey } from "../kv/api-keys.ts";
+import { kvBackfillApiKeyValueIndex } from "../kv/api-keys-index.ts";
+import { bootstrapCache } from "../kv/flush.ts";
+import { rebuildActiveKeyIds } from "../api-keys.ts";
+import { metrics } from "../metrics.ts";
+import { resetKvRateLimitsForTests } from "../rate-limit.ts";
+import { resetProxyStreamCountersForTests } from "../stream-limits.ts";
+import { AppState, state } from "../state.ts";
+import { setLogSinkForTests } from "../logger.ts";
+
+interface CapturedLog {
+  level: string;
+  record: Record<string, unknown>;
+}
+
+function captureLogs(): { records: CapturedLog[]; restore: () => void } {
+  const records: CapturedLog[] = [];
+  setLogSinkForTests((level, line) => {
+    records.push({ level, record: JSON.parse(line) });
+  });
+  return {
+    records,
+    restore: () => setLogSinkForTests(null),
+  };
+}
+
+async function setupKv(): Promise<Deno.Kv> {
+  if (state.kvFlushTimerId !== null) clearInterval(state.kvFlushTimerId);
+  const kv = await Deno.openKv(":memory:");
+  Deno.env.set("SETUP_TOKEN", "test-setup-token");
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
+  Object.assign(state, new AppState());
+  state.kv = kv;
+  await bootstrapCache();
+  await resetKvRateLimitsForTests();
+  await resetProxyStreamCountersForTests();
+  metrics.reset();
+  setLogSinkForTests(() => {});
+  return kv;
+}
+
+/**
+ * Persists an api-key record at the given id WITHOUT going through
+ * kvAddKey — i.e. without creating a value-index entry. Mimics records
+ * created on a deployment that pre-dates the index.
+ */
+async function persistLegacyApiKey(id: string, key: string): Promise<void> {
+  await state.kv.set([...API_KEY_PREFIX, id], {
+    id,
+    encryptedKey: await encryptApiKey(key),
+    useCount: 0,
+    status: "active" as const,
+    createdAt: Date.now(),
+  });
+}
+
+Deno.test(
+  "kvAddKey: duplicate same-value rejected when cache is stale (cross-instance)",
+  async () => {
+    const kv = await setupKv();
+    try {
+      const first = await kvAddKey("sk-cross-instance-dup");
+      assertEquals(first.success, true);
+
+      // Simulate the multi-instance scenario: instance B's in-memory cache
+      // has not yet caught up to the revision bump from instance A. The
+      // value is already in KV (with its index entry) but this instance
+      // still reports an empty cache.
+      state.cachedKeysById.clear();
+      state.cachedActiveKeyIds = [];
+
+      const second = await kvAddKey("sk-cross-instance-dup");
+      assertEquals(second.success, false);
+      assertEquals(second.error, "密钥已存在");
+
+      // KV must still hold exactly one record for this value.
+      const matching: string[] = [];
+      const iter = state.kv.list({ prefix: API_KEY_PREFIX });
+      for await (const entry of iter) {
+        const persisted = entry.value as { id: string; encryptedKey: string };
+        if (persisted.id === first.id) matching.push(persisted.id);
+      }
+      assertEquals(matching.length, 1);
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvAddKey + kvDeleteKey: re-adding the same value after delete works",
+  async () => {
+    const kv = await setupKv();
+    try {
+      const first = await kvAddKey("sk-cycle");
+      assertEquals(first.success, true);
+
+      const del = await kvDeleteKey(first.id!);
+      assertEquals(del.success, true);
+
+      // Index entry must be gone after delete.
+      const digest = await sha256Hex("sk-cycle");
+      const indexEntry = await state.kv.get<string>([
+        ...API_KEY_VALUE_INDEX_PREFIX,
+        digest,
+      ]);
+      assertEquals(indexEntry.value, null);
+
+      // Re-adding the same value succeeds with a fresh id.
+      const second = await kvAddKey("sk-cycle");
+      assertEquals(second.success, true);
+      assertEquals(second.id !== first.id, true);
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvDeleteKey: tolerates legacy record with no value-index entry",
+  async () => {
+    const kv = await setupKv();
+    try {
+      const id = "legacy-no-index";
+      await persistLegacyApiKey(id, "sk-legacy");
+      // Cache is intentionally not refreshed — exercise the path where
+      // kvDeleteKey must decrypt the persisted record to compute the
+      // digest itself.
+
+      const result = await kvDeleteKey(id);
+      assertEquals(result.success, true);
+
+      // After deletion the record is gone and there is no index entry
+      // either (because none existed in the first place).
+      const stored = await state.kv.get([...API_KEY_PREFIX, id]);
+      assertEquals(stored.value, null);
+      const digest = await sha256Hex("sk-legacy");
+      const indexEntry = await state.kv.get<string>([
+        ...API_KEY_VALUE_INDEX_PREFIX,
+        digest,
+      ]);
+      assertEquals(indexEntry.value, null);
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvBackfillApiKeyValueIndex: creates missing index entries idempotently",
+  async () => {
+    const kv = await setupKv();
+    try {
+      await persistLegacyApiKey("legacy-a", "sk-legacy-a");
+      await persistLegacyApiKey("legacy-b", "sk-legacy-b");
+
+      const first = await kvBackfillApiKeyValueIndex();
+      assertEquals(first.created, 2);
+      assertEquals(first.preExistingDuplicates, 0);
+
+      // Index entries now point at the right ids.
+      for (
+        const [id, key] of [
+          ["legacy-a", "sk-legacy-a"],
+          ["legacy-b", "sk-legacy-b"],
+        ] as const
+      ) {
+        const digest = await sha256Hex(key);
+        const indexEntry = await state.kv.get<string>([
+          ...API_KEY_VALUE_INDEX_PREFIX,
+          digest,
+        ]);
+        assertEquals(indexEntry.value, id);
+      }
+
+      // Second call is a no-op.
+      const second = await kvBackfillApiKeyValueIndex();
+      assertEquals(second.created, 0);
+      assertEquals(second.preExistingDuplicates, 0);
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvBackfillApiKeyValueIndex: leaves pre-existing duplicate alone and logs warn",
+  async () => {
+    const kv = await setupKv();
+    const logs = captureLogs();
+    try {
+      // Two records with the same plaintext value but different ids
+      // (the exact scenario issue #139 was about: written by separate
+      // instances before the index existed).
+      await persistLegacyApiKey("dup-keep", "sk-shared-value");
+      await persistLegacyApiKey("dup-other", "sk-shared-value");
+
+      const result = await kvBackfillApiKeyValueIndex();
+      // Exactly one record gets the index slot; the other is reported.
+      assertEquals(result.created, 1);
+      assertEquals(result.preExistingDuplicates, 1);
+
+      const digest = await sha256Hex("sk-shared-value");
+      const indexEntry = await state.kv.get<string>([
+        ...API_KEY_VALUE_INDEX_PREFIX,
+        digest,
+      ]);
+      // The index points at one of the two records (whichever the list
+      // iteration visited first); the other record is left intact in KV
+      // for an admin to clean up.
+      const winnerId = indexEntry.value;
+      assertEquals(typeof winnerId, "string");
+      const both = ["dup-keep", "dup-other"];
+      assertEquals(both.includes(winnerId as string), true);
+
+      const stored = await Promise.all(
+        both.map((id) => state.kv.get([...API_KEY_PREFIX, id])),
+      );
+      assertEquals(stored.every((entry) => entry.value !== null), true);
+
+      const warns = logs.records.filter(
+        (r) =>
+          r.level === "warn" &&
+          r.record.event === "api_key_value_index_pre_existing_duplicate",
+      );
+      assertEquals(warns.length, 1);
+      assertEquals(warns[0].record.keptId, winnerId);
+    } finally {
+      logs.restore();
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvAddKey: detects duplicate even after cache cleared but only after backfill",
+  async () => {
+    // Belt-and-braces variant: even when the legacy duplicate scenario
+    // has happened, once kvBackfillApiKeyValueIndex has run the index
+    // protects subsequent adds. A new same-value add must be rejected.
+    const kv = await setupKv();
+    try {
+      await persistLegacyApiKey("legacy-protected", "sk-protected");
+      await kvBackfillApiKeyValueIndex();
+
+      // Stale cache: this instance has no in-memory copy.
+      state.cachedKeysById.clear();
+      state.cachedActiveKeyIds = [];
+      rebuildActiveKeyIds();
+
+      const result = await kvAddKey("sk-protected");
+      assertEquals(result.success, false);
+      assertEquals(result.error, "密钥已存在");
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "bootstrapCache: backfills index entries for pre-existing records",
+  async () => {
+    const kv = await setupKv();
+    try {
+      await persistLegacyApiKey("bootstrap-legacy", "sk-bootstrap");
+
+      // Re-run bootstrap so the backfill path executes against the
+      // newly-inserted legacy record.
+      await bootstrapCache();
+
+      const digest = await sha256Hex("sk-bootstrap");
+      const indexEntry = await state.kv.get<string>([
+        ...API_KEY_VALUE_INDEX_PREFIX,
+        digest,
+      ]);
+      assertEquals(indexEntry.value, "bootstrap-legacy");
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);

--- a/src/__tests__/api-key-duplicate_test.ts
+++ b/src/__tests__/api-key-duplicate_test.ts
@@ -381,3 +381,51 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "kvAddKey: concurrent same-value race loser returns 密钥已存在 (not save-failed)",
+  async () => {
+    // Race scenario: kvAddKey reads a null indexEntry for a fresh
+    // plaintext, then another instance commits the same plaintext before
+    // this caller's atomic lands. The atomic CAS on indexEntry fails. Pre-
+    // fix the loser returned "密钥保存失败，请重试" → HTTP 400 generic
+    // conflict. Post-fix it re-reads indexKey; if non-null it returns
+    // "密钥已存在" → HTTP 409, matching the actual situation.
+    const kv = await setupKv();
+    try {
+      const plaintext = "sk-race-add";
+      const digest = await sha256Hex(plaintext);
+      const indexKey = [...API_KEY_VALUE_INDEX_PREFIX, digest];
+
+      // Inject the race: monkey-patch state.kv.atomic so that just before
+      // kvAddKey commits, a competing write lands on indexKey. The atomic
+      // CAS on the (formerly null) indexEntry must now fail, and the post-
+      // CAS re-read must trigger the duplicate-error branch.
+      const originalAtomic = state.kv.atomic.bind(state.kv);
+      let raced = false;
+      state.kv.atomic = (() => {
+        const tx = originalAtomic();
+        const originalCommit = tx.commit.bind(tx);
+        tx.commit = async () => {
+          if (!raced) {
+            raced = true;
+            await state.kv.set(indexKey, "race-winner-id");
+          }
+          return originalCommit();
+        };
+        return tx;
+      }) as typeof state.kv.atomic;
+
+      try {
+        const result = await kvAddKey(plaintext);
+        assertEquals(result.success, false);
+        assertEquals(result.error, "密钥已存在");
+      } finally {
+        state.kv.atomic = originalAtomic;
+      }
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);

--- a/src/__tests__/api-key-duplicate_test.ts
+++ b/src/__tests__/api-key-duplicate_test.ts
@@ -85,14 +85,17 @@ Deno.test(
       assertEquals(second.success, false);
       assertEquals(second.error, "密钥已存在");
 
-      // KV must still hold exactly one record for this value.
-      const matching: string[] = [];
+      // KV must still hold exactly one record under the api-key prefix.
+      // Filtering by first.id would silently miss a duplicate written
+      // under a different id — which is exactly the regression #139
+      // guards against. Count every record instead.
+      let total = 0;
       const iter = state.kv.list({ prefix: API_KEY_PREFIX });
       for await (const entry of iter) {
-        const persisted = entry.value as { id: string; encryptedKey: string };
-        if (persisted.id === first.id) matching.push(persisted.id);
+        void entry;
+        total += 1;
       }
-      assertEquals(matching.length, 1);
+      assertEquals(total, 1);
     } finally {
       setLogSinkForTests(null);
       kv.close();
@@ -291,6 +294,87 @@ Deno.test(
         digest,
       ]);
       assertEquals(indexEntry.value, "bootstrap-legacy");
+    } finally {
+      setLogSinkForTests(null);
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "assertCurrentApiKey: defensive type guard rejects non-object values",
+  async () => {
+    // assertCurrentApiKey runs against arbitrary KV payloads — pre-#145
+    // a null / non-object value tripped a TypeError instead of the
+    // expected "格式不兼容" error. Lock the defensive shape down.
+    const { assertCurrentApiKey } = await import("../api-key-record.ts");
+    for (const value of [null, undefined, 42, "string", true]) {
+      try {
+        assertCurrentApiKey(value);
+        throw new Error(
+          `assertCurrentApiKey accepted ${JSON.stringify(value)}`,
+        );
+      } catch (error) {
+        if (!(error instanceof Error)) throw error;
+        assertEquals(
+          error.message.startsWith("API key 存储格式不兼容"),
+          true,
+          `unexpected error for ${JSON.stringify(value)}: ${error.message}`,
+        );
+      }
+    }
+  },
+);
+
+Deno.test(
+  "kvDeleteKey: blocks dangling index from concurrent backfill (CAS)",
+  async () => {
+    // Race scenario: kvDeleteKey reads a null indexEntry for a legacy
+    // record, then a concurrent backfill writes the index for that
+    // record's digest before kvDeleteKey commits. Pre-fix the delete
+    // proceeded anyway and left a dangling index pointing at the just-
+    // deleted id, permanently locking that plaintext out of future
+    // kvAddKey. Post-fix the delete CASes the indexEntry slot itself
+    // and must fail (returns 密钥删除失败) so the caller can retry.
+    const kv = await setupKv();
+    try {
+      const id = "race-legacy";
+      await persistLegacyApiKey(id, "sk-race");
+      const digest = await sha256Hex("sk-race");
+      const indexKey = [...API_KEY_VALUE_INDEX_PREFIX, digest];
+
+      // Inject the race: monkey-patch state.kv.atomic so that just before
+      // kvDeleteKey commits, we slip an index write into KV. The atomic
+      // commit's CAS on the (formerly null) indexEntry must now fail.
+      const originalAtomic = state.kv.atomic.bind(state.kv);
+      let raced = false;
+      state.kv.atomic = (() => {
+        const tx = originalAtomic();
+        const originalCommit = tx.commit.bind(tx);
+        tx.commit = async () => {
+          if (!raced) {
+            raced = true;
+            await state.kv.set(indexKey, id);
+          }
+          return originalCommit();
+        };
+        return tx;
+      }) as typeof state.kv.atomic;
+
+      try {
+        const result = await kvDeleteKey(id);
+        assertEquals(result.success, false);
+        assertEquals(result.error, "密钥删除失败，请重试");
+      } finally {
+        state.kv.atomic = originalAtomic;
+      }
+
+      // Main record AND index must still both exist — nothing got
+      // deleted because the CAS conflict aborted the atomic.
+      const stored = await state.kv.get([...API_KEY_PREFIX, id]);
+      assertEquals(stored.value !== null, true);
+      const indexEntry = await state.kv.get<string>(indexKey);
+      assertEquals(indexEntry.value, id);
     } finally {
       setLogSinkForTests(null);
       kv.close();

--- a/src/api-key-record.ts
+++ b/src/api-key-record.ts
@@ -1,8 +1,25 @@
 import type { ApiKey } from "./types.ts";
+import { isEncryptedApiKey } from "./secrets.ts";
 
 export type PersistedApiKey = Omit<ApiKey, "key">;
 
 export function toPersistedApiKey(key: ApiKey): PersistedApiKey {
   const { key: _plaintext, ...persisted } = key;
   return persisted;
+}
+
+/**
+ * Runtime-validates a value read out of KV against the current persisted
+ * api-key shape. Lifted out of `src/kv/api-keys.ts` so migration helpers
+ * in sibling files can reuse it without an import cycle.
+ */
+export function assertCurrentApiKey(value: unknown): PersistedApiKey {
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.encryptedKey !== "string") {
+    throw new Error("API key 存储格式不兼容：需要先运行密钥迁移");
+  }
+  if (!isEncryptedApiKey(raw.encryptedKey)) {
+    throw new Error("API key 密文格式错误");
+  }
+  return raw as unknown as PersistedApiKey;
 }

--- a/src/api-key-record.ts
+++ b/src/api-key-record.ts
@@ -14,6 +14,9 @@ export function toPersistedApiKey(key: ApiKey): PersistedApiKey {
  * in sibling files can reuse it without an import cycle.
  */
 export function assertCurrentApiKey(value: unknown): PersistedApiKey {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("API key 存储格式不兼容：记录不是对象");
+  }
   const raw = value as Record<string, unknown>;
   if (typeof raw.encryptedKey !== "string") {
     throw new Error("API key 存储格式不兼容：需要先运行密钥迁移");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,15 @@ export const KV_PREFIX = "cerebras-proxy";
 export const CONFIG_KEY = [KV_PREFIX, "meta", "config"] as const;
 export const MODEL_CATALOG_KEY = [KV_PREFIX, "meta", "model_catalog"] as const;
 export const API_KEY_PREFIX = [KV_PREFIX, "keys", "api"] as const;
+// Secondary index keyed by sha256 of the plaintext key value, mapping back
+// to the api-key id. Lets kvAddKey detect a same-value duplicate even when
+// the in-memory cache is stale (e.g. another instance just added the same
+// value, or this instance's revision check hasn't caught up yet). See #139.
+export const API_KEY_VALUE_INDEX_PREFIX = [
+  KV_PREFIX,
+  "keys",
+  "api_value_idx",
+] as const;
 export const PROXY_KEY_PREFIX = [KV_PREFIX, "keys", "proxy"] as const;
 export const ADMIN_PASSWORD_KEY = [
   KV_PREFIX,

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -29,6 +29,20 @@ async function sha256Bytes(value: string): Promise<Uint8Array> {
   );
 }
 
+/**
+ * Returns a hex-encoded SHA-256 digest of the input. Used as a stable,
+ * non-secret identifier for "have I seen this exact value before?" checks
+ * (e.g. the API key value index) without storing the plaintext alongside.
+ */
+export async function sha256Hex(value: string): Promise<string> {
+  const bytes = await sha256Bytes(value);
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
 export async function compareSecret(a: string, b: string): Promise<boolean> {
   const [aDigest, bDigest] = await Promise.all([
     sha256Bytes(a),

--- a/src/kv/api-keys-index.ts
+++ b/src/kv/api-keys-index.ts
@@ -1,0 +1,73 @@
+/**
+ * Secondary index for api-key plaintext values: sha256(value) → id.
+ * The index lets `kvAddKey` reject same-value duplicates even when the
+ * caller's in-memory cache is stale (e.g. another instance just added
+ * the same value, or the local revision check has not caught up).
+ *
+ * Issue #139.
+ */
+
+import { API_KEY_PREFIX, API_KEY_VALUE_INDEX_PREFIX } from "../constants.ts";
+import { assertCurrentApiKey } from "../api-key-record.ts";
+import { sha256Hex } from "../crypto.ts";
+import { decryptApiKey } from "../secrets.ts";
+import { logger } from "../logger.ts";
+import { state } from "../state.ts";
+
+export function valueIndexKey(digest: string): Deno.KvKey {
+  return [...API_KEY_VALUE_INDEX_PREFIX, digest];
+}
+
+/**
+ * Walks the api-keys KV prefix and ensures every record has a matching
+ * value-index entry. Idempotent — safe to run on every cold start.
+ *
+ * Behaviour:
+ * - Missing index → atomically create it pointing at the record's id.
+ * - Existing index points at this id → no-op.
+ * - Existing index points at a different id → log warn but do not
+ *   overwrite. This means a pre-existing duplicate (created before the
+ *   index existed, see #139) is left in place; one of them keeps being
+ *   the "canonical" record protected by the index, the other will simply
+ *   no longer block subsequent same-value adds — admins can clean it up
+ *   manually. We deliberately avoid auto-deleting either record from
+ *   here because a backfill path is the wrong place to drop user data.
+ *
+ * Concurrency: a CAS conflict means another instance won the race for
+ * the same digest; treat as success (the entry is now there). Any other
+ * error is surfaced so the caller can decide whether to fail bootstrap.
+ */
+export async function kvBackfillApiKeyValueIndex(): Promise<{
+  created: number;
+  preExistingDuplicates: number;
+}> {
+  let created = 0;
+  let preExistingDuplicates = 0;
+  const iter = state.kv.list({ prefix: API_KEY_PREFIX });
+  for await (const entry of iter) {
+    const persisted = assertCurrentApiKey(entry.value);
+    const plaintext = await decryptApiKey(persisted.encryptedKey);
+    const digest = await sha256Hex(plaintext);
+    const indexKey = valueIndexKey(digest);
+    const indexEntry = await state.kv.get<string>(indexKey);
+    if (indexEntry.value === persisted.id) continue;
+    if (indexEntry.value !== null && indexEntry.value !== persisted.id) {
+      preExistingDuplicates++;
+      logger.warn("api_key_value_index_pre_existing_duplicate", {
+        keptId: indexEntry.value,
+        duplicateId: persisted.id,
+      });
+      continue;
+    }
+    const result = await state.kv.atomic()
+      .check(indexEntry)
+      .set(indexKey, persisted.id)
+      .commit();
+    if (result.ok) created++;
+    // CAS lost: another instance set the index for this digest first.
+    // Either it points at our id (idempotent) or at a duplicate (which
+    // the next iteration / next bootstrap will surface). Either way the
+    // current run does not need to retry.
+  }
+  return { created, preExistingDuplicates };
+}

--- a/src/kv/api-keys-index.ts
+++ b/src/kv/api-keys-index.ts
@@ -60,14 +60,17 @@ export async function kvBackfillApiKeyValueIndex(): Promise<{
       continue;
     }
     const result = await state.kv.atomic()
+      .check(entry)
       .check(indexEntry)
       .set(indexKey, persisted.id)
       .commit();
     if (result.ok) created++;
-    // CAS lost: another instance set the index for this digest first.
-    // Either it points at our id (idempotent) or at a duplicate (which
-    // the next iteration / next bootstrap will surface). Either way the
-    // current run does not need to retry.
+    // CAS lost: either another instance set the index for this digest
+    // first (idempotent if it points at our id; surfaced next iteration
+    // if at a duplicate), or the main record was concurrently modified
+    // / deleted (in which case writing the index would have produced a
+    // dangling pointer). The current run does not need to retry —
+    // `entry` is now stale anyway.
   }
   return { created, preExistingDuplicates };
 }

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -1,27 +1,22 @@
 import type { ApiKey } from "../types.ts";
-import { type PersistedApiKey, toPersistedApiKey } from "../api-key-record.ts";
+import {
+  assertCurrentApiKey,
+  type PersistedApiKey,
+  toPersistedApiKey,
+} from "../api-key-record.ts";
 import { API_KEY_CACHE_REVISION_KEY, API_KEY_PREFIX } from "../constants.ts";
 import { generateId } from "../utils.ts";
+import { sha256Hex } from "../crypto.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
-import { decryptApiKey, encryptApiKey, isEncryptedApiKey } from "../secrets.ts";
+import { decryptApiKey, encryptApiKey } from "../secrets.ts";
 import { state } from "../state.ts";
 import {
   getNextRevisionValue,
   recordApiKeyCacheRevision,
 } from "./revisions.ts";
+import { valueIndexKey } from "./api-keys-index.ts";
 
 type LegacyApiKey = Omit<ApiKey, "encryptedKey"> & { key: string };
-
-function assertCurrentApiKey(value: unknown): PersistedApiKey {
-  const raw = value as Record<string, unknown>;
-  if (typeof raw.encryptedKey !== "string") {
-    throw new Error("API key 存储格式不兼容：需要先运行密钥迁移");
-  }
-  if (!isEncryptedApiKey(raw.encryptedKey)) {
-    throw new Error("API key 密文格式错误");
-  }
-  return raw as unknown as PersistedApiKey;
-}
 
 async function hydrateApiKey(value: unknown): Promise<ApiKey> {
   const persisted = assertCurrentApiKey(value);
@@ -137,11 +132,18 @@ let lastApiKeyCreatedAtMs = 0;
 export async function kvAddKey(
   key: string,
 ): Promise<{ success: boolean; id?: string; error?: string }> {
+  // The in-memory cache check is an optimistic fast path: if THIS instance
+  // already knows the value, skip the KV roundtrips. The authoritative
+  // duplicate check is the value-index entry below, which catches the
+  // multi-instance / stale-cache case described in issue #139.
   const allKeys = Array.from(state.cachedKeysById.values());
   const existingKey = allKeys.find((k) => k.key === key);
   if (existingKey) {
     return { success: false, error: "密钥已存在" };
   }
+
+  const valueDigest = await sha256Hex(key);
+  const indexKey = valueIndexKey(valueDigest);
 
   const id = generateId();
   const now = Date.now();
@@ -159,18 +161,26 @@ export async function kvAddKey(
     createdAt,
   };
 
-  const [revisionEntry, idEntry] = await Promise.all([
+  const [revisionEntry, idEntry, indexEntry] = await Promise.all([
     state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
     state.kv.get([...API_KEY_PREFIX, id]),
+    state.kv.get<string>(indexKey),
   ]);
   if (idEntry.value !== null) {
     return { success: false, error: "密钥保存冲突，请重试" };
   }
+  if (indexEntry.value !== null) {
+    // Another instance (or a previous request that landed before this
+    // instance's cache caught up) already persisted this exact value.
+    return { success: false, error: "密钥已存在" };
+  }
   const revision = getNextRevisionValue(revisionEntry);
   const result = await state.kv.atomic()
     .check(idEntry)
+    .check(indexEntry)
     .check(revisionEntry)
     .set([...API_KEY_PREFIX, id], toPersistedApiKey(newKey))
+    .set(indexKey, id)
     .set(API_KEY_CACHE_REVISION_KEY, revision)
     .commit();
   if (!result.ok) {
@@ -187,19 +197,38 @@ export async function kvDeleteKey(
   id: string,
 ): Promise<{ success: boolean; error?: string }> {
   const key = [...API_KEY_PREFIX, id];
-  const result = await state.kv.get(key);
+  const result = await state.kv.get<PersistedApiKey>(key);
   if (!result.value) {
     return { success: false, error: "密钥不存在" };
   }
 
+  // Resolve the value digest so the secondary index entry can be removed
+  // atomically alongside the main record. Prefer the in-memory plaintext
+  // (avoid one decrypt round-trip) and fall back to decrypting the
+  // persisted record if the cache doesn't have it.
+  const cached = state.cachedKeysById.get(id);
+  const plaintext = cached?.key ??
+    await decryptApiKey(result.value.encryptedKey);
+  const valueDigest = await sha256Hex(plaintext);
+  const indexKey = valueIndexKey(valueDigest);
+  const indexEntry = await state.kv.get<string>(indexKey);
+
   const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
   const revision = getNextRevisionValue(revisionEntry);
-  const deleteResult = await state.kv.atomic()
+  let atomic = state.kv.atomic()
     .check(result)
     .check(revisionEntry)
     .delete(key)
-    .set(API_KEY_CACHE_REVISION_KEY, revision)
-    .commit();
+    .set(API_KEY_CACHE_REVISION_KEY, revision);
+  if (indexEntry.value === id) {
+    // Only delete the index entry when it actually points at this id —
+    // a legacy record may pre-date the index (no entry to delete) and a
+    // pre-existing duplicate could share the same digest with a different
+    // surviving id, in which case the index must keep pointing at the
+    // survivor.
+    atomic = atomic.check(indexEntry).delete(indexKey);
+  }
+  const deleteResult = await atomic.commit();
   if (!deleteResult.ok) {
     return { success: false, error: "密钥删除失败，请重试" };
   }

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -184,6 +184,14 @@ export async function kvAddKey(
     .set(API_KEY_CACHE_REVISION_KEY, revision)
     .commit();
   if (!result.ok) {
+    // CAS lost — by far the most likely cause is another instance just
+    // wrote the same plaintext via its own atomic. Re-read the index so
+    // the caller (and ultimately the HTTP handler) gets the duplicate
+    // error → 409 instead of the generic save-conflict error → 400.
+    const postCheck = await state.kv.get<string>(indexKey);
+    if (postCheck.value !== null) {
+      return { success: false, error: "密钥已存在" };
+    }
     return { success: false, error: "密钥保存失败，请重试" };
   }
   state.cachedKeysById.set(id, newKey);
@@ -197,10 +205,16 @@ export async function kvDeleteKey(
   id: string,
 ): Promise<{ success: boolean; error?: string }> {
   const key = [...API_KEY_PREFIX, id];
-  const result = await state.kv.get<PersistedApiKey>(key);
+  const result = await state.kv.get(key);
   if (!result.value) {
     return { success: false, error: "密钥不存在" };
   }
+  // Validate at the runtime boundary — the generic on state.kv.get is a
+  // TypeScript-level promise, not a guarantee. A malformed / corrupted
+  // record (migration bug, manual KV write, cross-version payload)
+  // surfaces as the expected "格式不兼容" error here instead of a less
+  // diagnosable TypeError on the next property access.
+  const persisted = assertCurrentApiKey(result.value);
 
   // Resolve the value digest so the secondary index entry can be removed
   // atomically alongside the main record. Prefer the in-memory plaintext
@@ -208,7 +222,7 @@ export async function kvDeleteKey(
   // persisted record if the cache doesn't have it.
   const cached = state.cachedKeysById.get(id);
   const plaintext = cached?.key ??
-    await decryptApiKey(result.value.encryptedKey);
+    await decryptApiKey(persisted.encryptedKey);
   const valueDigest = await sha256Hex(plaintext);
   const indexKey = valueIndexKey(valueDigest);
   // Fetch indexEntry and revisionEntry in parallel — mirrors the

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -211,22 +211,30 @@ export async function kvDeleteKey(
     await decryptApiKey(result.value.encryptedKey);
   const valueDigest = await sha256Hex(plaintext);
   const indexKey = valueIndexKey(valueDigest);
-  const indexEntry = await state.kv.get<string>(indexKey);
-
-  const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
+  // Fetch indexEntry and revisionEntry in parallel — mirrors the
+  // Promise.all pattern in kvAddKey and saves one KV round-trip.
+  const [indexEntry, revisionEntry] = await Promise.all([
+    state.kv.get<string>(indexKey),
+    state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
+  ]);
   const revision = getNextRevisionValue(revisionEntry);
+  // Always CAS the index entry — including the "no entry yet" case for a
+  // legacy record. Without this, a concurrent backfill that creates the
+  // index between our read and our commit would leave a dangling index
+  // pointing at the just-deleted id, permanently locking that plaintext
+  // value out of future kvAddKey calls.
   let atomic = state.kv.atomic()
     .check(result)
+    .check(indexEntry)
     .check(revisionEntry)
     .delete(key)
     .set(API_KEY_CACHE_REVISION_KEY, revision);
   if (indexEntry.value === id) {
     // Only delete the index entry when it actually points at this id —
-    // a legacy record may pre-date the index (no entry to delete) and a
-    // pre-existing duplicate could share the same digest with a different
-    // surviving id, in which case the index must keep pointing at the
-    // survivor.
-    atomic = atomic.check(indexEntry).delete(indexKey);
+    // a pre-existing duplicate could share the same digest with a
+    // different surviving id, in which case the index must keep pointing
+    // at the survivor.
+    atomic = atomic.delete(indexKey);
   }
   const deleteResult = await atomic.commit();
   if (!deleteResult.ok) {

--- a/src/kv/flush.ts
+++ b/src/kv/flush.ts
@@ -16,6 +16,7 @@ import {
   resolveKvFlushIntervalMs,
 } from "./config.ts";
 import { kvGetAllKeys } from "./api-keys.ts";
+import { kvBackfillApiKeyValueIndex } from "./api-keys-index.ts";
 import { kvGetAllProxyKeys } from "./proxy-keys.ts";
 import { getApiKeyCacheRevision, getAuthCacheRevision } from "./revisions.ts";
 import { metrics } from "../metrics.ts";
@@ -189,4 +190,24 @@ export async function bootstrapCache(): Promise<void> {
   state.authCacheRevisionLastCheckedAt = Date.now();
   state.apiKeyCacheRevision = await getApiKeyCacheRevision();
   state.apiKeyCacheRevisionLastCheckedAt = Date.now();
+
+  // Issue #139: ensure the secondary value-digest index exists for every
+  // persisted api key. Idempotent — safe to run on every cold start. Run
+  // after the cache is populated so a subsequent kvAddKey can rely on
+  // the index for cross-instance duplicate detection.
+  try {
+    const { created, preExistingDuplicates } =
+      await kvBackfillApiKeyValueIndex();
+    if (created > 0 || preExistingDuplicates > 0) {
+      logger.info("api_key_value_index_backfill", {
+        created,
+        preExistingDuplicates,
+      });
+    }
+  } catch (error) {
+    // Backfill failure must not block startup — duplicate detection
+    // simply degrades to the in-memory cache check until the next
+    // bootstrap (or a successful kvAddKey path that creates the entry).
+    logger.warn("api_key_value_index_backfill_failed", {}, error);
+  }
 }


### PR DESCRIPTION
Closes #139.

## 问题

`kvAddKey` 用 `state.cachedKeysById` 判重，多实例部署中**不可靠**：

```ts
const allKeys = Array.from(state.cachedKeysById.values());
const existingKey = allKeys.find((k) => k.key === key);
if (existingKey) return { success: false, error: "密钥已存在" };
```

实例 A 加完 key 后 revision 已 bump，但实例 B 的 `apiKeyCacheRevisionLastCheckedAt` 节流窗口（最长 5s）还没过期。此时 admin 通过实例 B 的连接再加同一个 key value：

- 实例 B 缓存里没这条记录 → 视作"新 key"
- 生成新 ID，atomic 写入用的是新 ID 作为 KV key → `.check(idEntry)` 永远不会撞到已有同 value 的记录
- KV 中出现两条不同 ID 但相同 plaintext 的记录，都进 active 池被独立轮询 → **同一个 Cerebras key 占两份配额、被消费两次**

## 修复

新增 `sha256(plaintext) → id` 二级索引。

### 实现

1. **常量** `API_KEY_VALUE_INDEX_PREFIX = [KV_PREFIX, "keys", "api_value_idx"]`。
2. **`kvAddKey`** 计算 digest，读 indexEntry，存在即返回 `密钥已存在`；atomic commit 同时 `.check(indexEntry).set(indexKey, id)`。两个实例并发同 value 会争 KV 同一个 slot，CAS 让其中一个失败而非各自落盘。
3. **`kvDeleteKey`** 先拿 plaintext（cache 优先，落到解密 fallback）、算 digest、读 indexEntry。原子删除主记录 + 条件删除 index（`indexEntry.value === id`）。legacy 记录无 index 时 delete 仍正常。
4. **`kvBackfillApiKeyValueIndex`**（新增模块 `src/kv/api-keys-index.ts`）由 `bootstrapCache` 调用：
   - 遍历 api-keys 前缀，缺 index 则原子创建。
   - 已存在且 value === 自己 id：no-op。
   - 已存在但指向其他 id（pre-existing duplicate，在索引存在之前由本 bug 产生）：保留两份记录（不在 backfill 路径里删用户数据），结构化日志 `api_key_value_index_pre_existing_duplicate` 上报 `keptId`、`duplicateId`，让 admin 决定。
   - 幂等。冷启动失败不阻塞 bootstrap（`logger.warn("api_key_value_index_backfill_failed", ...)` 后继续；duplicate 检测降级为内存缓存检查，直到下次 bootstrap 或某次成功的 kvAddKey）。

### 重构

- `assertCurrentApiKey` 从 `src/kv/api-keys.ts` 上移到 `src/api-key-record.ts`，`src/kv/api-keys-index.ts` 不会和主 KV 模块产生 import cycle。
- `src/kv/api-keys.ts` 加完新代码后 335 行（超 300 行 large-files cap），把 `kvBackfillApiKeyValueIndex` 和 `valueIndexKey` 抽到 `src/kv/api-keys-index.ts`。`src/kv/api-keys.ts` 回到 266 行。

### 关于 sha256 安全性

Cerebras API key 是 64+ 字符随机 token，sha256 hex 不可反查。攻击者若已有 KV 读权限，能直接看 `encryptedKey`；index 不增加额外攻击面。

## 测试

新文件 `src/__tests__/api-key-duplicate_test.ts` 10 例：

1. **duplicate same-value rejected when cache is stale (cross-instance)**：复现 issue 场景，第二次 add 返回 `密钥已存在`，KV 中只有 1 条记录。
2. **delete + re-add of the same value works**：删完 index entry 也清掉，能重新加。
3. **delete tolerates legacy record with no index entry**：bypass `kvAddKey` 直接写一条无 index 的记录，能成功删掉。
4. **backfill creates missing entries and is idempotent**：第一轮 created=2，第二轮 created=0。
5. **backfill leaves pre-existing duplicate alone and logs warn**：两条同 value 不同 id，backfill 后 created=1、preExistingDuplicates=1，warn 日志带 keptId。
6. **duplicate detection still works after backfill of a legacy record and a stale-cache add**：legacy → backfill → 清 cache → 再 add 同 value → 拒绝。
7. **bootstrapCache backfills index entries for legacy records**：端到端 bootstrap 验证。
8. **assertCurrentApiKey: defensive type guard rejects non-object values**：null / undefined / primitive 全部抛 "格式不兼容"。
9. **kvDeleteKey: blocks dangling index from concurrent backfill (CAS)**：monkey-patch atomic 注入 race，验证 delete 在 CAS 冲突下整体回滚。
10. **kvAddKey: concurrent same-value race loser returns 密钥已存在**：monkey-patch atomic 注入竞争写入，验证 loser 拿到 duplicate error (→ 409)。

## 验证

本地 Deno 2.8.0：

```
deno task fmt:check / lint / naming:check / complexity:check ✓
deno task module-boundaries:check / large-files:check / tech-debt:check ✓
deno task duplicate-code:check / unused-deps:check / openapi:check ✓
deno task check ✓
deno task test:ci ✓ 173 passed
deno task coverage:check ✓ lines 79.70%
```

## 与 issue 的关系

直接闭合 #139。和 #140 / #144 互不耦合。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入基于密钥明文摘要的二级索引与回填机制，启动时可补全缺失索引以增强重复检测
  * 新增运行时格式校验与摘要工具以提升读写健壮性

* **Bug 修复**
  * 改进在多实例/缓存陈旧情况下的重复值检测与删除原子性，避免误删或悬挂索引

* **测试**
  * 增加全面回归测试，覆盖重复拒绝、回填、并发冲突与兼容性场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->