### PR TITLE
chore: clean up readiness diagnostics and API key KV updates

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -632,6 +632,25 @@
           "401": { "$ref": "#/components/responses/Problem" }
         }
       }
+    },
+    "/api/diagnostics": {
+      "get": {
+        "tags": ["Health"],
+        "operationId": "getDiagnostics",
+        "summary": "Detailed readiness diagnostics (admin-only)",
+        "security": [{ "AdminToken": [] }],
+        "responses": {
+          "200": {
+            "description": "Readiness diagnostics with individual checks",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Diagnostics" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Problem" }
+        }
+      }
     }
   },
   "components": {
@@ -784,6 +803,14 @@
         "additionalProperties": false
       },
       "Readiness": {
+        "type": "object",
+        "required": ["ready"],
+        "properties": {
+          "ready": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      },
+      "Diagnostics": {
         "type": "object",
         "required": ["ready", "checks"],
         "properties": {

--- a/docs/runbooks/deployment-readiness.md
+++ b/docs/runbooks/deployment-readiness.md
@@ -32,8 +32,12 @@ should only be sent to a fully initialized instance.
    ```sh
    curl -fsS "$BASE_URL/readyz"
    ```
-3. If `/healthz` passes but `/readyz` returns `503`, inspect the JSON `checks`
-   object:
+3. If `/healthz` passes but `/readyz` returns `503`, use the admin diagnostics
+   endpoint to inspect individual checks:
+   ```sh
+   curl -fsS -H "X-Admin-Token: $ADMIN_TOKEN" "$BASE_URL/api/diagnostics"
+   ```
+   The response includes a `checks` object:
    - `keyEncryptionSecret`: set or fix `KEY_ENCRYPTION_SECRET`.
    - `kv`: verify Deno KV availability and local KV path permissions.
    - `config`: verify the KV config shape is compatible.

--- a/scripts/dast-check.ts
+++ b/scripts/dast-check.ts
@@ -97,6 +97,12 @@ const probes: Probe[] = [
     path: "/%2e%2e/%2e%2e/etc/passwd",
     expectedStatus: 404,
   },
+  {
+    name: "diagnostics requires auth",
+    path: "/api/diagnostics",
+    expectedStatus: 401,
+    expectCorsOrigin: null,
+  },
 ];
 
 function parseArgs(args: string[]): { baseUrl: string; timeoutMs: number } {

--- a/scripts/openapi-routes.ts
+++ b/scripts/openapi-routes.ts
@@ -36,4 +36,5 @@ export const EXPECTED_ROUTES: Route[] = [
   { method: "get", path: "/api/config" },
   { method: "patch", path: "/api/config" },
   { method: "get", path: "/api/metrics" },
+  { method: "get", path: "/api/diagnostics" },
 ];

--- a/src/__tests__/api-key-kv_test.ts
+++ b/src/__tests__/api-key-kv_test.ts
@@ -1,0 +1,158 @@
+import { assertEquals } from "@std/assert";
+import { AppState, state } from "../state.ts";
+import { kvAddKey, kvUpdateKey } from "../kv/api-keys.ts";
+import { kvGetApiKeyById } from "../kv/api-keys.ts";
+import { markKeyInvalid } from "../api-keys.ts";
+import { API_KEY_PREFIX } from "../constants.ts";
+import { setLogSinkForTests } from "../logger.ts";
+import { testKey } from "../services/api-keys.ts";
+
+async function setupKv(): Promise<Deno.Kv> {
+  if (state.kvFlushTimerId !== null) clearInterval(state.kvFlushTimerId);
+  const kv = await Deno.openKv(":memory:");
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
+  Object.assign(state, new AppState());
+  state.kv = kv;
+  setLogSinkForTests(() => {});
+  return kv;
+}
+
+Deno.test("kvUpdateKey: retries on atomic conflict and eventually succeeds", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-retry-test-key");
+  const id = addResult.id!;
+  await kvGetApiKeyById(id);
+
+  const originalAtomic = kv.atomic.bind(kv);
+  let callCount = 0;
+  kv.atomic = () => {
+    callCount++;
+    const op = originalAtomic();
+    if (callCount <= 2) {
+      op.commit = () => {
+        return Promise.resolve(
+          { ok: false } as unknown as Deno.KvCommitResult,
+        );
+      };
+    }
+    return op;
+  };
+
+  try {
+    const result = await kvUpdateKey(id, { status: "inactive" });
+    assertEquals(result.updated, true);
+    assertEquals(state.cachedKeysById.get(id)?.status, "inactive");
+  } finally {
+    kv.atomic = originalAtomic;
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("kvUpdateKey: returns updated false and cleans cache when KV entry missing", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-missing-entry-test");
+  const id = addResult.id!;
+  await kvGetApiKeyById(id);
+
+  state.dirtyKeyIds.add(id);
+  state.keyCooldownUntil.set(id, Date.now() + 60_000);
+
+  await kv.delete([...API_KEY_PREFIX, id]);
+
+  try {
+    const result = await kvUpdateKey(id, { status: "inactive" });
+    assertEquals(result.updated, false);
+    assertEquals(state.cachedKeysById.has(id), false);
+    assertEquals(state.keyCooldownUntil.has(id), false);
+    assertEquals(state.dirtyKeyIds.has(id), false);
+  } finally {
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("kvUpdateKey: returns updated false when key not in memory or KV", async () => {
+  const kv = await setupKv();
+
+  try {
+    const result = await kvUpdateKey("nonexistent-id", { status: "inactive" });
+    assertEquals(result.updated, false);
+  } finally {
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("markKeyInvalid: dirtyKeyIds retained on commit failure", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-dirty-fail-test");
+  const id = addResult.id!;
+  await kvGetApiKeyById(id);
+  state.dirtyKeyIds.add(id);
+
+  const originalAtomic = kv.atomic.bind(kv);
+  kv.atomic = () => {
+    const op = originalAtomic();
+    op.commit = () => {
+      return Promise.resolve(
+        { ok: false } as unknown as Deno.KvCommitResult,
+      );
+    };
+    return op;
+  };
+
+  try {
+    await markKeyInvalid(id);
+    assertEquals(state.dirtyKeyIds.has(id), true);
+    assertEquals(state.cachedKeysById.get(id)?.status, "invalid");
+  } finally {
+    kv.atomic = originalAtomic;
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("markKeyInvalid: dirtyKeyIds deleted on commit success", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-dirty-success-test");
+  const id = addResult.id!;
+  await kvGetApiKeyById(id);
+  state.dirtyKeyIds.add(id);
+
+  try {
+    await markKeyInvalid(id);
+    assertEquals(state.dirtyKeyIds.has(id), false);
+    assertEquals(state.cachedKeysById.get(id)?.status, "invalid");
+    const entry = await kv.get([...API_KEY_PREFIX, id]);
+    const persisted = entry.value as { status: string };
+    assertEquals(persisted.status, "invalid");
+  } finally {
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("testKey: returns error when key concurrently deleted (kvUpdateKey returns updated false)", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-concurrent-delete-test");
+  const id = addResult.id!;
+  await kvGetApiKeyById(id);
+  state.cachedModelPool = ["test-model"];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => Promise.resolve(new Response("{}", { status: 200 }));
+
+  await kv.delete([...API_KEY_PREFIX, id]);
+
+  try {
+    const result = await testKey(id);
+    assertEquals(result.success, false);
+    assertEquals(result.status, "invalid");
+    assertEquals(result.error, "密钥不存在");
+  } finally {
+    globalThis.fetch = originalFetch;
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});

--- a/src/__tests__/api-key-kv_test.ts
+++ b/src/__tests__/api-key-kv_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { AppState, state } from "../state.ts";
-import { kvAddKey, kvUpdateKey } from "../kv/api-keys.ts";
-import { kvGetApiKeyById } from "../kv/api-keys.ts";
+import { kvAddKey, kvGetApiKeyById, kvUpdateKey } from "../kv/api-keys.ts";
+import { kvMigrateApiKeysToEncrypted } from "../kv/api-keys-migrate.ts";
 import { markKeyInvalid } from "../api-keys.ts";
 import { API_KEY_PREFIX } from "../constants.ts";
 import { setLogSinkForTests } from "../logger.ts";
@@ -84,7 +84,87 @@ Deno.test("kvUpdateKey: returns updated false when key not in memory or KV", asy
   }
 });
 
-Deno.test("markKeyInvalid: dirtyKeyIds retained on commit failure", async () => {
+Deno.test("kvMigrateApiKeysToEncrypted: preserves dirty cached stats while merging migrated keys", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-dirty-cache-migration-test");
+  const dirtyId = addResult.id!;
+  await kvGetApiKeyById(dirtyId);
+  const dirtyKey = state.cachedKeysById.get(dirtyId);
+  if (!dirtyKey) throw new Error("Expected API key to be cached");
+  dirtyKey.useCount = 7;
+  dirtyKey.lastUsed = 1_234;
+  state.dirtyKeyIds.add(dirtyId);
+
+  const legacyId = "legacy-migration-key";
+  await kv.set([...API_KEY_PREFIX, legacyId], {
+    id: legacyId,
+    key: "sk-legacy-migration-test",
+    useCount: 0,
+    status: "active",
+    createdAt: 1,
+  });
+
+  try {
+    const migrated = await kvMigrateApiKeysToEncrypted();
+    assertEquals(migrated, 1);
+
+    const cached = state.cachedKeysById.get(dirtyId);
+    if (!cached) throw new Error("Expected dirty API key to remain cached");
+    assertEquals(cached.useCount, 7);
+    assertEquals(cached.lastUsed, 1_234);
+    assertEquals(state.dirtyKeyIds.has(dirtyId), true);
+
+    const migratedEntry = await kv.get([...API_KEY_PREFIX, legacyId]);
+    assertEquals((migratedEntry.value as { key?: string }).key, undefined);
+    assertEquals(
+      typeof (migratedEntry.value as { encryptedKey?: string }).encryptedKey,
+      "string",
+    );
+  } finally {
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("markKeyInvalid: retries atomic conflicts until invalid status is persisted", async () => {
+  const kv = await setupKv();
+  const addResult = await kvAddKey("sk-invalid-retry-test");
+  const id = addResult.id!;
+  await kvGetApiKeyById(id);
+
+  const originalAtomic = kv.atomic.bind(kv);
+  let commitCount = 0;
+  kv.atomic = () => {
+    const op = originalAtomic();
+    const originalCommit = op.commit.bind(op);
+    op.commit = () => {
+      commitCount++;
+      if (commitCount <= 2) {
+        return Promise.resolve(
+          { ok: false } as unknown as Deno.KvCommitResult,
+        );
+      }
+      return originalCommit();
+    };
+    return op;
+  };
+
+  try {
+    await markKeyInvalid(id);
+    assertEquals(commitCount, 3);
+    assertEquals(state.dirtyKeyIds.has(id), false);
+    assertEquals(state.cachedKeysById.get(id)?.status, "invalid");
+    const entry = await kv.get([...API_KEY_PREFIX, id]);
+    const persisted = entry.value as { status: string };
+    assertEquals(persisted.status, "invalid");
+  } finally {
+    kv.atomic = originalAtomic;
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("markKeyInvalid: dirtyKeyIds retained after retry exhaustion", async () => {
   const kv = await setupKv();
   const addResult = await kvAddKey("sk-dirty-fail-test");
   const id = addResult.id!;
@@ -92,18 +172,24 @@ Deno.test("markKeyInvalid: dirtyKeyIds retained on commit failure", async () => 
   state.dirtyKeyIds.add(id);
 
   const originalAtomic = kv.atomic.bind(kv);
+  let commitCount = 0;
   kv.atomic = () => {
     const op = originalAtomic();
     op.commit = () => {
-      return Promise.resolve(
-        { ok: false } as unknown as Deno.KvCommitResult,
-      );
+      commitCount++;
+      if (commitCount < 10) {
+        return Promise.resolve(
+          { ok: false } as unknown as Deno.KvCommitResult,
+        );
+      }
+      throw new Error("forced atomic failure after retry exhaustion");
     };
     return op;
   };
 
   try {
     await markKeyInvalid(id);
+    assertEquals(commitCount, 10);
     assertEquals(state.dirtyKeyIds.has(id), true);
     assertEquals(state.cachedKeysById.get(id)?.status, "invalid");
   } finally {

--- a/src/__tests__/health_test.ts
+++ b/src/__tests__/health_test.ts
@@ -80,19 +80,19 @@ Deno.test("health: GET /api/diagnostics returns checks with admin token", async 
   const kv = await setupKv();
   const handler = createHandler(createRouter());
 
-  const setupRes = await handler(
-    new Request(`${BASE}/api/auth/setup`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Setup-Token": "test-setup-token",
-      },
-      body: JSON.stringify({ password: "testpass" }),
-    }),
-  );
-  const { token } = await setupRes.json();
-
   try {
+    const setupRes = await handler(
+      new Request(`${BASE}/api/auth/setup`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Setup-Token": "test-setup-token",
+        },
+        body: JSON.stringify({ password: "testpass" }),
+      }),
+    );
+    assertEquals(setupRes.status, 200);
+    const { token } = await setupRes.json();
     const res = await handler(makeReq("/api/diagnostics", {
       "X-Admin-Token": token,
     }));

--- a/src/__tests__/health_test.ts
+++ b/src/__tests__/health_test.ts
@@ -24,11 +24,11 @@ async function setupKv(): Promise<Deno.Kv> {
   return kv;
 }
 
-function makeReq(path: string): Request {
-  return new Request(`${BASE}${path}`);
+function makeReq(path: string, headers?: HeadersInit): Request {
+  return new Request(`${BASE}${path}`, { headers });
 }
 
-Deno.test("health: GET /readyz returns ready when KV and secrets are configured", async () => {
+Deno.test("health: GET /readyz returns 200 with only ready field when healthy", async () => {
   const kv = await setupKv();
   const handler = createHandler(createRouter());
 
@@ -37,16 +37,14 @@ Deno.test("health: GET /readyz returns ready when KV and secrets are configured"
     assertEquals(res.status, 200);
     const body = await res.json();
     assertEquals(body.ready, true);
-    assertEquals(body.checks.keyEncryptionSecret, true);
-    assertEquals(body.checks.kv, true);
-    assertEquals(body.checks.config, true);
+    assertEquals(body.checks, undefined);
   } finally {
     setLogSinkForTests(null);
     kv.close();
   }
 });
 
-Deno.test("health: GET /readyz returns 503 when KV is unavailable", async () => {
+Deno.test("health: GET /readyz returns 503 with only ready field when KV unavailable", async () => {
   const kv = await setupKv();
   const handler = createHandler(createRouter());
   const originalKv = state.kv;
@@ -57,10 +55,54 @@ Deno.test("health: GET /readyz returns 503 when KV is unavailable", async () => 
     assertEquals(res.status, 503);
     const body = await res.json();
     assertEquals(body.ready, false);
-    assertEquals(body.checks.kv, false);
-    assertEquals(body.checks.config, false);
+    assertEquals(body.checks, undefined);
   } finally {
     state.kv = originalKv;
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("health: GET /api/diagnostics returns 401 without admin token", async () => {
+  const kv = await setupKv();
+  const handler = createHandler(createRouter());
+
+  try {
+    const res = await handler(makeReq("/api/diagnostics"));
+    assertEquals(res.status, 401);
+  } finally {
+    setLogSinkForTests(null);
+    kv.close();
+  }
+});
+
+Deno.test("health: GET /api/diagnostics returns checks with admin token", async () => {
+  const kv = await setupKv();
+  const handler = createHandler(createRouter());
+
+  const setupRes = await handler(
+    new Request(`${BASE}/api/auth/setup`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Setup-Token": "test-setup-token",
+      },
+      body: JSON.stringify({ password: "testpass" }),
+    }),
+  );
+  const { token } = await setupRes.json();
+
+  try {
+    const res = await handler(makeReq("/api/diagnostics", {
+      "X-Admin-Token": token,
+    }));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.ready, true);
+    assertEquals(body.checks.keyEncryptionSecret, true);
+    assertEquals(body.checks.kv, true);
+    assertEquals(body.checks.config, true);
+  } finally {
     setLogSinkForTests(null);
     kv.close();
   }

--- a/src/__tests__/integration_test.ts
+++ b/src/__tests__/integration_test.ts
@@ -1434,6 +1434,37 @@ Deno.test("integration: upstream model-not-found classification is bounded", asy
   }
 });
 
+Deno.test("integration: non-model-not-found 404 returns sanitized error without upstream body", async () => {
+  const kv = await setupKv();
+  const handler = buildHandler();
+  await enableProxyPublicAccess(handler);
+  await addActiveApiKey("sk-upstream-test");
+  const secretBody = JSON.stringify({
+    error: { message: "some internal upstream detail" },
+  });
+  const restoreFetch = installUpstreamResponse(
+    new Response(secretBody, {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+
+  try {
+    const res = await handler(
+      makeReq("POST", "/v1/chat/completions", {
+        body: { messages: [{ role: "user", content: "hi" }] },
+      }),
+    );
+    const text = await res.text();
+    assertEquals(res.status, 404);
+    assertEquals(text.includes("Upstream request failed"), true);
+    assertEquals(text.includes("some internal upstream detail"), false);
+  } finally {
+    restoreFetch();
+    kv.close();
+  }
+});
+
 Deno.test("integration: successful upstream stream is still passed through", async () => {
   const kv = await setupKv();
   const handler = buildHandler();

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -1,6 +1,7 @@
 import {
   API_KEY_CACHE_REVISION_KEY,
   API_KEY_PREFIX,
+  KV_ATOMIC_MAX_RETRIES,
   PROXY_KEY_AUTH_REFRESH_INTERVAL_MS,
 } from "./constants.ts";
 import { toPersistedApiKey } from "./api-key-record.ts";
@@ -11,6 +12,7 @@ import {
   recordApiKeyCacheRevision,
 } from "./kv/revisions.ts";
 import { kvMergeAllApiKeysIntoCache } from "./kv/api-keys.ts";
+import { waitForKvAtomicRetry } from "./kv/atomic-retry.ts";
 import { logger } from "./logger.ts";
 
 export function rebuildActiveKeyIds(): void {
@@ -130,27 +132,33 @@ export async function markKeyInvalid(id: string): Promise<void> {
   rebuildActiveKeyIds();
   try {
     const key = [...API_KEY_PREFIX, id];
-    const [entry, revisionEntry] = await Promise.all([
-      state.kv.get(key),
-      state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
-    ]);
-    if (!entry.value) {
-      state.cachedKeysById.delete(id);
-      state.keyCooldownUntil.delete(id);
-      state.dirtyKeyIds.delete(id);
-      rebuildActiveKeyIds();
-      return;
+    for (let attempt = 0; attempt < KV_ATOMIC_MAX_RETRIES; attempt++) {
+      const [entry, revisionEntry] = await Promise.all([
+        state.kv.get(key),
+        state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
+      ]);
+      if (!entry.value) {
+        state.cachedKeysById.delete(id);
+        state.keyCooldownUntil.delete(id);
+        state.dirtyKeyIds.delete(id);
+        rebuildActiveKeyIds();
+        return;
+      }
+      const revision = getNextRevisionValue(revisionEntry);
+      const result = await state.kv.atomic()
+        .check(entry)
+        .check(revisionEntry)
+        .set(key, toPersistedApiKey(keyEntry))
+        .set(API_KEY_CACHE_REVISION_KEY, revision)
+        .commit();
+      if (result.ok) {
+        state.dirtyKeyIds.delete(id);
+        recordApiKeyCacheRevision(revision);
+        return;
+      }
+      await waitForKvAtomicRetry(attempt);
     }
-    const revision = getNextRevisionValue(revisionEntry);
-    const result = await state.kv.atomic()
-      .check(entry)
-      .check(revisionEntry)
-      .set(key, toPersistedApiKey(keyEntry))
-      .set(API_KEY_CACHE_REVISION_KEY, revision)
-      .commit();
-    if (!result.ok) throw new Error("API key invalidation write conflict");
-    state.dirtyKeyIds.delete(id);
-    recordApiKeyCacheRevision(revision);
+    throw new Error("API key invalidation write conflict");
   } catch (error) {
     logger.error("api_key_invalidation_write_failed", { keyId: id }, error);
   }

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -127,7 +127,6 @@ export async function markKeyInvalid(id: string): Promise<void> {
   if (keyEntry.status === "invalid") return;
   keyEntry.status = "invalid";
   state.keyCooldownUntil.delete(id);
-  state.dirtyKeyIds.delete(id);
   rebuildActiveKeyIds();
   try {
     const key = [...API_KEY_PREFIX, id];
@@ -135,7 +134,13 @@ export async function markKeyInvalid(id: string): Promise<void> {
       state.kv.get(key),
       state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
     ]);
-    if (!entry.value) return;
+    if (!entry.value) {
+      state.cachedKeysById.delete(id);
+      state.keyCooldownUntil.delete(id);
+      state.dirtyKeyIds.delete(id);
+      rebuildActiveKeyIds();
+      return;
+    }
     const revision = getNextRevisionValue(revisionEntry);
     const result = await state.kv.atomic()
       .check(entry)
@@ -144,9 +149,9 @@ export async function markKeyInvalid(id: string): Promise<void> {
       .set(API_KEY_CACHE_REVISION_KEY, revision)
       .commit();
     if (!result.ok) throw new Error("API key invalidation write conflict");
+    state.dirtyKeyIds.delete(id);
     recordApiKeyCacheRevision(revision);
   } catch (error) {
-    state.dirtyKeyIds.add(id);
     logger.error("api_key_invalidation_write_failed", { keyId: id }, error);
   }
 }

--- a/src/handlers/api-keys.ts
+++ b/src/handlers/api-keys.ts
@@ -1,11 +1,7 @@
 import { adminJsonResponse, adminProblemResponse } from "../http.ts";
 import { maskKey, parseBatchInput } from "../utils.ts";
-import {
-  kvAddKey,
-  kvDeleteKey,
-  kvGetAllKeys,
-  kvMigrateApiKeysToEncrypted,
-} from "../kv/api-keys.ts";
+import { kvAddKey, kvDeleteKey, kvGetAllKeys } from "../kv/api-keys.ts";
+import { kvMigrateApiKeysToEncrypted } from "../kv/api-keys-migrate.ts";
 import { testKey } from "../services/api-keys.ts";
 import { logger } from "../logger.ts";
 import type { Router } from "../router.ts";

--- a/src/handlers/health.ts
+++ b/src/handlers/health.ts
@@ -1,4 +1,4 @@
-import { jsonResponse } from "../http.ts";
+import { adminJsonResponse, jsonResponse } from "../http.ts";
 import { kvGetConfig } from "../kv/config.ts";
 import { state } from "../state.ts";
 import type { Router } from "../router.ts";
@@ -13,7 +13,7 @@ function getHealthz(): Response {
   return new Response("ok", { status: 200 });
 }
 
-async function getReadyz(): Promise<Response> {
+async function getReadinessChecks(): Promise<ReadinessChecks> {
   const checks: ReadinessChecks = {
     keyEncryptionSecret: Boolean(Deno.env.get("KEY_ENCRYPTION_SECRET")?.trim()),
     kv: Boolean(state.kv),
@@ -29,15 +29,31 @@ async function getReadyz(): Promise<Response> {
     }
   }
 
-  const ready = Object.values(checks).every(Boolean);
-  return jsonResponse({ ready, checks }, {
+  return checks;
+}
+
+function isReady(checks: ReadinessChecks): boolean {
+  return Object.values(checks).every(Boolean);
+}
+
+async function getReadyz(): Promise<Response> {
+  const checks = await getReadinessChecks();
+  const ready = isReady(checks);
+  return jsonResponse({ ready }, {
     status: ready ? 200 : 503,
     cors: "admin",
   });
 }
 
+async function getDiagnostics(): Promise<Response> {
+  const checks = await getReadinessChecks();
+  const ready = isReady(checks);
+  return adminJsonResponse({ ready, checks });
+}
+
 export function register(router: Router): void {
   router
     .get("/healthz", getHealthz)
-    .get("/readyz", getReadyz);
+    .get("/readyz", getReadyz)
+    .get("/api/diagnostics", getDiagnostics);
 }

--- a/src/kv/api-keys-migrate.ts
+++ b/src/kv/api-keys-migrate.ts
@@ -1,0 +1,52 @@
+import type { ApiKey } from "../types.ts";
+import { API_KEY_PREFIX } from "../constants.ts";
+import { rebuildActiveKeyIds } from "../api-keys.ts";
+import { encryptApiKey } from "../secrets.ts";
+import { state } from "../state.ts";
+import { kvGetAllKeys } from "./api-keys.ts";
+
+type LegacyApiKey = Omit<ApiKey, "encryptedKey"> & { key: string };
+
+export async function kvMigrateApiKeysToEncrypted(): Promise<number> {
+  let migrated = 0;
+  const iter = state.kv.list({ prefix: API_KEY_PREFIX });
+  for await (const entry of iter) {
+    const value = entry.value as Partial<LegacyApiKey> & Partial<ApiKey>;
+    if (typeof value.encryptedKey === "string") continue;
+    if (typeof value.key !== "string") {
+      throw new Error("API key 迁移失败：旧记录缺少明文 key");
+    }
+
+    const encryptedKey = await encryptApiKey(value.key);
+    const migratedValue = {
+      id: value.id,
+      useCount: value.useCount,
+      lastUsed: value.lastUsed,
+      status: value.status,
+      createdAt: value.createdAt,
+      encryptedKey,
+    };
+    if (
+      typeof migratedValue.id !== "string" ||
+      typeof migratedValue.useCount !== "number" ||
+      typeof migratedValue.status !== "string" ||
+      typeof migratedValue.createdAt !== "number"
+    ) {
+      throw new Error("API key 迁移失败：旧记录结构不完整");
+    }
+    const result = await state.kv.atomic()
+      .check(entry)
+      .set(entry.key, migratedValue)
+      .commit();
+    if (!result.ok) throw new Error("API key 迁移失败：KV 写入冲突");
+    state.cachedKeysById.delete(migratedValue.id);
+    migrated++;
+  }
+  if (migrated > 0) {
+    state.cachedKeysById = new Map(
+      (await kvGetAllKeys()).map((key) => [key.id, key]),
+    );
+    rebuildActiveKeyIds();
+  }
+  return migrated;
+}

--- a/src/kv/api-keys-migrate.ts
+++ b/src/kv/api-keys-migrate.ts
@@ -1,9 +1,8 @@
 import type { ApiKey } from "../types.ts";
 import { API_KEY_PREFIX } from "../constants.ts";
-import { rebuildActiveKeyIds } from "../api-keys.ts";
 import { encryptApiKey } from "../secrets.ts";
 import { state } from "../state.ts";
-import { kvGetAllKeys } from "./api-keys.ts";
+import { kvMergeAllApiKeysIntoCache } from "./api-keys.ts";
 
 type LegacyApiKey = Omit<ApiKey, "encryptedKey"> & { key: string };
 
@@ -43,10 +42,7 @@ export async function kvMigrateApiKeysToEncrypted(): Promise<number> {
     migrated++;
   }
   if (migrated > 0) {
-    state.cachedKeysById = new Map(
-      (await kvGetAllKeys()).map((key) => [key.id, key]),
-    );
-    rebuildActiveKeyIds();
+    await kvMergeAllApiKeysIntoCache();
   }
   return migrated;
 }

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -4,7 +4,11 @@ import {
   type PersistedApiKey,
   toPersistedApiKey,
 } from "../api-key-record.ts";
-import { API_KEY_CACHE_REVISION_KEY, API_KEY_PREFIX } from "../constants.ts";
+import {
+  API_KEY_CACHE_REVISION_KEY,
+  API_KEY_PREFIX,
+  KV_ATOMIC_MAX_RETRIES,
+} from "../constants.ts";
 import { generateId } from "../utils.ts";
 import { sha256Hex } from "../crypto.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
@@ -15,8 +19,7 @@ import {
   recordApiKeyCacheRevision,
 } from "./revisions.ts";
 import { valueIndexKey } from "./api-keys-index.ts";
-
-type LegacyApiKey = Omit<ApiKey, "encryptedKey"> & { key: string };
+import { waitForKvAtomicRetry } from "./atomic-retry.ts";
 
 async function hydrateApiKey(value: unknown): Promise<ApiKey> {
   const persisted = assertCurrentApiKey(value);
@@ -82,50 +85,6 @@ export async function kvGetApiKeyById(id: string): Promise<ApiKey | null> {
   state.cachedKeysById.set(id, hydrated);
   rebuildActiveKeyIds();
   return hydrated;
-}
-
-export async function kvMigrateApiKeysToEncrypted(): Promise<number> {
-  let migrated = 0;
-  const iter = state.kv.list({ prefix: API_KEY_PREFIX });
-  for await (const entry of iter) {
-    const value = entry.value as Partial<LegacyApiKey> & Partial<ApiKey>;
-    if (typeof value.encryptedKey === "string") continue;
-    if (typeof value.key !== "string") {
-      throw new Error("API key 迁移失败：旧记录缺少明文 key");
-    }
-
-    const encryptedKey = await encryptApiKey(value.key);
-    const migratedValue = {
-      id: value.id,
-      useCount: value.useCount,
-      lastUsed: value.lastUsed,
-      status: value.status,
-      createdAt: value.createdAt,
-      encryptedKey,
-    };
-    if (
-      typeof migratedValue.id !== "string" ||
-      typeof migratedValue.useCount !== "number" ||
-      typeof migratedValue.status !== "string" ||
-      typeof migratedValue.createdAt !== "number"
-    ) {
-      throw new Error("API key 迁移失败：旧记录结构不完整");
-    }
-    const result = await state.kv.atomic()
-      .check(entry)
-      .set(entry.key, migratedValue)
-      .commit();
-    if (!result.ok) throw new Error("API key 迁移失败：KV 写入冲突");
-    state.cachedKeysById.delete(migratedValue.id);
-    migrated++;
-  }
-  if (migrated > 0) {
-    state.cachedKeysById = new Map(
-      (await kvGetAllKeys()).map((key) => [key.id, key]),
-    );
-    rebuildActiveKeyIds();
-  }
-  return migrated;
 }
 
 let lastApiKeyCreatedAtMs = 0;
@@ -265,24 +224,65 @@ export async function kvDeleteKey(
 export async function kvUpdateKey(
   id: string,
   updates: Partial<ApiKey>,
-): Promise<void> {
-  const key = [...API_KEY_PREFIX, id];
-  const existing = state.cachedKeysById.get(id) ??
-    (await kvGetApiKeyById(id));
-  if (!existing) return;
-  const updated = { ...existing, ...updates };
-  const entry = await state.kv.get<PersistedApiKey>(key);
-  if (!entry.value) return;
-  const revisionEntry = await state.kv.get<number>(API_KEY_CACHE_REVISION_KEY);
-  const revision = getNextRevisionValue(revisionEntry);
-  const result = await state.kv.atomic()
-    .check(entry)
-    .check(revisionEntry)
-    .set(key, toPersistedApiKey(updated))
-    .set(API_KEY_CACHE_REVISION_KEY, revision)
-    .commit();
-  if (!result.ok) throw new Error("密钥更新失败：KV 写入冲突");
-  state.cachedKeysById.set(id, updated);
-  rebuildActiveKeyIds();
-  recordApiKeyCacheRevision(revision);
+): Promise<{ updated: boolean }> {
+  const cached = state.cachedKeysById.get(id);
+  if (!cached && !(await kvGetApiKeyById(id))) {
+    return { updated: false };
+  }
+
+  const kvKey = [...API_KEY_PREFIX, id];
+
+  for (let attempt = 0; attempt < KV_ATOMIC_MAX_RETRIES; attempt++) {
+    const [entry, revisionEntry] = await Promise.all([
+      state.kv.get<PersistedApiKey>(kvKey),
+      state.kv.get<number>(API_KEY_CACHE_REVISION_KEY),
+    ]);
+
+    if (!entry.value) {
+      const local = state.cachedKeysById.get(id);
+      if (local) {
+        state.cachedKeysById.delete(id);
+        state.keyCooldownUntil.delete(id);
+        state.dirtyKeyIds.delete(id);
+        rebuildActiveKeyIds();
+      }
+      return { updated: false };
+    }
+
+    const persisted = await hydrateApiKey(entry.value);
+    const local = state.cachedKeysById.get(id);
+    const plaintext = local?.key ?? persisted.key;
+
+    const useCount = updates.useCount ??
+      Math.max(local?.useCount ?? 0, persisted.useCount);
+    const lastUsed = updates.lastUsed ??
+      (Math.max(local?.lastUsed ?? 0, persisted.lastUsed ?? 0) || undefined);
+
+    const updated: ApiKey = {
+      ...persisted,
+      ...updates,
+      key: plaintext,
+      useCount,
+      lastUsed,
+    };
+
+    const revision = getNextRevisionValue(revisionEntry);
+    const result = await state.kv.atomic()
+      .check(entry)
+      .check(revisionEntry)
+      .set(kvKey, toPersistedApiKey(updated))
+      .set(API_KEY_CACHE_REVISION_KEY, revision)
+      .commit();
+
+    if (result.ok) {
+      state.cachedKeysById.set(id, updated);
+      rebuildActiveKeyIds();
+      recordApiKeyCacheRevision(revision);
+      return { updated: true };
+    }
+
+    await waitForKvAtomicRetry(attempt);
+  }
+
+  throw new Error("密钥更新失败：达到最大重试次数");
 }

--- a/src/kv/atomic-retry.ts
+++ b/src/kv/atomic-retry.ts
@@ -1,0 +1,5 @@
+export async function waitForKvAtomicRetry(attempt: number): Promise<void> {
+  const baseMs = Math.min(10 * 2 ** attempt, 500);
+  const jitter = Math.random() * baseMs;
+  await new Promise((resolve) => setTimeout(resolve, baseMs + jitter));
+}

--- a/src/kv/config.ts
+++ b/src/kv/config.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeKvFlushIntervalMs } from "../utils.ts";
 import { normalizeModelPool } from "../models.ts";
 import { state } from "../state.ts";
+import { waitForKvAtomicRetry } from "./atomic-retry.ts";
 import { getNextRevisionValue, recordAuthCacheRevision } from "./revisions.ts";
 
 export function resolveKvFlushIntervalMs(config: ProxyConfig | null): number {
@@ -129,9 +130,7 @@ export async function kvEnsureConfigEntry(): Promise<
       .set(CONFIG_KEY, config)
       .commit();
     if (!result.ok) {
-      const baseMs = Math.min(10 * 2 ** attempt, 500);
-      const jitter = Math.random() * baseMs;
-      await new Promise((r) => setTimeout(r, baseMs + jitter));
+      await waitForKvAtomicRetry(attempt);
     }
   }
   throw new Error("KV 配置迁移失败：达到最大重试次数");
@@ -173,9 +172,7 @@ export async function kvUpdateConfig(
       if (nextRevision !== null) recordAuthCacheRevision(nextRevision);
       return validatedConfig;
     }
-    const baseMs = Math.min(10 * 2 ** attempt, 500);
-    const jitter = Math.random() * baseMs;
-    await new Promise((r) => setTimeout(r, baseMs + jitter));
+    await waitForKvAtomicRetry(attempt);
   }
   throw new Error("配置更新失败：达到最大重试次数");
 }

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -1,10 +1,27 @@
 import { CEREBRAS_API_URL, UPSTREAM_TEST_TIMEOUT_MS } from "../constants.ts";
 import { fetchWithTimeout, isAbortError, safeJsonParse } from "../utils.ts";
 import { state } from "../state.ts";
+import type { ApiKey } from "../types.ts";
 import { kvGetApiKeyById, kvUpdateKey } from "../kv/api-keys.ts";
 import { removeModelFromPool } from "../kv/model-catalog.ts";
 import { isModelNotFoundPayload, isModelNotFoundText } from "../models.ts";
 import { logger } from "../logger.ts";
+
+async function updateTestKeyStatus(
+  id: string,
+  status: ApiKey["status"],
+): Promise<{ success: boolean; status: string; error?: string } | null> {
+  try {
+    const { updated } = await kvUpdateKey(id, { status });
+    if (!updated) {
+      return { success: false, status: "invalid", error: "密钥不存在" };
+    }
+    return null;
+  } catch (error) {
+    logger.error("api_key_status_update_failed", { keyId: id }, error);
+    return { success: false, status: "error", error: "密钥状态更新失败" };
+  }
+}
 
 /**
  * Tests an API key against the configured model pool; an empty pool is a config error.
@@ -43,13 +60,15 @@ export async function testKey(
 
     if (response.ok) {
       await response.body?.cancel();
-      await kvUpdateKey(id, { status: "active" });
+      const fail = await updateTestKeyStatus(id, "active");
+      if (fail) return fail;
       return { success: true, status: "active" };
     }
 
     if (response.status === 401 || response.status === 403) {
       await response.body?.cancel();
-      await kvUpdateKey(id, { status: "invalid" });
+      const fail = await updateTestKeyStatus(id, "invalid");
+      if (fail) return fail;
       return {
         success: false,
         status: "invalid",
@@ -66,13 +85,15 @@ export async function testKey(
       if (modelNotFound) {
         await response.body?.cancel();
         await removeModelFromPool(testModel, "model_not_found");
-        await kvUpdateKey(id, { status: "active" });
+        const fail = await updateTestKeyStatus(id, "active");
+        if (fail) return fail;
         return { success: true, status: "active" };
       }
     }
 
     await response.body?.cancel();
-    await kvUpdateKey(id, { status: "inactive" });
+    const fail = await updateTestKeyStatus(id, "inactive");
+    if (fail) return fail;
     return {
       success: false,
       status: "inactive",
@@ -80,7 +101,8 @@ export async function testKey(
     };
   } catch (error) {
     logger.error("api_key_test_failed", { keyId: id }, error);
-    await kvUpdateKey(id, { status: "inactive" });
+    const fail = await updateTestKeyStatus(id, "inactive");
+    if (fail) return fail;
     return {
       success: false,
       status: "inactive",

--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -159,7 +159,13 @@ export async function testModelAvailability(
         "upstream_responses_total",
         response.status === 401 ? "401" : "403",
       );
-      await kvUpdateKey(activeKey.id, { status: "invalid" });
+      try {
+        await kvUpdateKey(activeKey.id, { status: "invalid" });
+      } catch (error) {
+        logger.warn("model_test_key_invalidation_failed", {
+          keyId: activeKey.id,
+        }, error);
+      }
     } else {
       metrics.inc("upstream_responses_total", "other");
     }

--- a/src/services/proxy.ts
+++ b/src/services/proxy.ts
@@ -230,8 +230,11 @@ export async function forwardChatCompletion(
 
     recordCircuitOutcome(apiResponse.status);
 
+    let upstreamErrorBodyConsumed = false;
+
     if (apiResponse.status === 404) {
       const bodyRead = await readBoundedBodyText(apiResponse.body);
+      upstreamErrorBodyConsumed = true;
       if (!bodyRead.ok) {
         metrics.inc("upstream_responses_total", "404_body_too_large");
         metrics.inc("proxy_requests_total", "upstream_error");
@@ -252,7 +255,9 @@ export async function forwardChatCompletion(
     }
 
     if (!apiResponse.ok) {
-      await discardBoundedUpstreamErrorBody(apiResponse);
+      if (!upstreamErrorBodyConsumed) {
+        await discardBoundedUpstreamErrorBody(apiResponse);
+      }
       if (apiResponse.status === 429) {
         markKeyCooldownFrom429(apiKeyData.id, apiResponse);
         metrics.inc("upstream_responses_total", "429");


### PR DESCRIPTION
## 摘要

打包合并 issue #140 中 5 项 nice-to-have 清理，不引入新依赖、不扩大范围、保持 upstream 错误响应脱敏。

- `/readyz` 收敛为只暴露 `{ ready }`；详细 checks 移到 admin-only `GET /api/diagnostics`（受 `X-Admin-Token` 保护）。
- `kvUpdateKey` 改为返回 `{ updated: boolean }` 并对 atomic conflict 重试最多 `KV_ATOMIC_MAX_RETRIES` 次：
  - 内存和 KV 都找不到 key 时返回 `{ updated: false }`，不再静默吞掉。
  - 内存有 key 但 KV entry 已不存在时清理 `cachedKeysById` / `keyCooldownUntil` / `dirtyKeyIds` 后返回 `{ updated: false }`。
  - 重试时重新读取 entry 和 revision，避免复用旧 versionstamp；保留本地 plaintext 与较大的 useCount/lastUsed。
- `markKeyInvalid` 在 atomic commit 成功后再 `dirtyKeyIds.delete(id)`；commit 失败/抛错时不再补 add dirty，从而保留已有的 useCount/lastUsed dirty 统计。
- `services/proxy.forwardChatCompletion` 在每次 attempt 中跟踪 `upstreamErrorBodyConsumed`，404 body 已被读取用于 model-not-found 检测时跳过重复 `discardBoundedUpstreamErrorBody`。
- 抽取 `src/kv/atomic-retry.ts#waitForKvAtomicRetry` 共享指数退避 + jitter；`src/kv/config.ts` 中两处重复 backoff 替换为该 helper。
- 顺带把 `kvMigrateApiKeysToEncrypted` 拆到 `src/kv/api-keys-migrate.ts`，让 `src/kv/api-keys.ts` 不超 large-files 阈值。

## 调用方调整

- `services/api-keys.testKey`：新增 `updateTestKeyStatus` helper 包裹所有 `kvUpdateKey` 调用；返回 `{ updated: false }` 时给出 `{ success: false, status: "invalid", error: "密钥不存在" }`；catch 分支里二次调用 `kvUpdateKey` 也单独 try/catch，避免裸抛。
- `services/models.testModelAvailability`：401/403 时 `kvUpdateKey(... { status: "invalid" })` 包 try/catch，sanitized warn 日志，并发删除不再让模型测试接口抛 500。

## 故意未做

- 没有实现 issue #140 中“用 logger.debug 记录 upstream 404 body”的建议。当前 logger 没有 debug level，且把 upstream 响应体写入 info 日志会带来更高的泄露风险与噪音。

## 文档与 schema

- `docs/openapi.json`：`Readiness` 改为只 required `[\"ready\"]`；新增 `Diagnostics` schema 与 `GET /api/diagnostics`（`AdminToken`）。
- `scripts/openapi-routes.ts#EXPECTED_ROUTES`：补 `{ method: \"get\", path: \"/api/diagnostics\" }`。
- `docs/runbooks/deployment-readiness.md`：第 3 步改为 503 时管理员通过 `X-Admin-Token` 调 `/api/diagnostics` 看 checks。
- `scripts/dast-check.ts`：新增 `/api/diagnostics` 401 + `expectCorsOrigin: null` 探针；`/readyz` 探针保持 `\"ready\":true`。

## 验证

聚焦：
- `deno test --allow-net --allow-env --allow-read --allow-write src/__tests__/api-key-kv_test.ts src/__tests__/health_test.ts src/__tests__/integration_test.ts` — 71/71 通过（覆盖迁移 cache merge、markKeyInvalid retry、diagnostics cleanup、非 model-not-found 404 sanitized）。
- `deno task openapi:check` — 33 routes 通过。

Full gate：fmt:check / lint / naming:check / complexity:check / module-boundaries:check / agents:check / large-files:check / tech-debt:check / duplicate-code:check / unused-deps:check / openapi:check / check / test（**184 passed**）/ test:ci（**184 passed**）/ coverage:lcov + coverage:check（**lines 80.55%**，阈值 75%）/ test:performance。

`deno task dast:check` 已在本地服务上执行通过：12 probes checked。

## 测试计划

- [x] /readyz 仅返回 `ready`，KV 不可用时 503 + `ready:false`，无 checks 字段
- [x] /api/diagnostics 无 token 401，admin token 200 含 checks
- [x] kvUpdateKey atomic conflict 重试到成功
- [x] kvUpdateKey KV entry 缺失时清理 cache 并返回 updated:false
- [x] markKeyInvalid CAS 冲突重试到 invalid status 持久化，retry exhaustion 后保留已有 dirtyKeyIds，commit 成功删除 dirtyKeyIds
- [x] testKey 在 key 被并发删除时返回 invalid/密钥不存在，不抛 500
- [x] 非 model-not-found 404 仍返回 sanitized upstream error，不泄露 upstream body

Addresses #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 新增管理诊断端点，支持admin token认证
  * 优化就绪检查响应结构

* **Bug修复**
  * 增强API密钥更新的可靠性，引入重试机制
  * 改进错误响应处理，防止信息泄露

* **文档**
  * 更新部署就绪运行手册，指引使用诊断端点排查问题

* **测试**
  * 新增密钥更新、健康检查、集成测试用例，提高覆盖率

* **重构**
  * 重组健康检查逻辑与密钥迁移模块
  * 统一KV原子操作重试流程

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->