### PR TITLE
Skip malformed API key records during cache hydration

### DIFF
--- a/src/__tests__/api-key-hydration-skip_test.ts
+++ b/src/__tests__/api-key-hydration-skip_test.ts
@@ -122,6 +122,11 @@ Deno.test(
       );
       assertEquals(warns.length, 1);
       assertEquals(warns[0].record.keyId, "bad-invalid-cipher");
+
+      assertEquals(
+        metrics.snapshot().api_key_hydrate_failed_total?.skipped,
+        1,
+      );
     } finally {
       logs.restore();
       kv.close();
@@ -162,6 +167,11 @@ Deno.test(
       );
       assertEquals(warns.length, 1);
       assertEquals(warns[0].record.keyId, "bad-decrypt");
+
+      assertEquals(
+        metrics.snapshot().api_key_hydrate_failed_total?.skipped,
+        1,
+      );
     } finally {
       logs.restore();
       kv.close();

--- a/src/__tests__/api-key-hydration-skip_test.ts
+++ b/src/__tests__/api-key-hydration-skip_test.ts
@@ -1,0 +1,279 @@
+/**
+ * Regression tests for issue #144: kvGetAllKeys / kvMergeAllApiKeysIntoCache
+ * must skip individual records that fail hydration rather than failing the
+ * entire batch, and must not evict cached entries whose KV records were
+ * present-but-unreadable.
+ */
+
+import { assertEquals } from "@std/assert";
+import { API_KEY_PREFIX } from "../constants.ts";
+import { encryptApiKey } from "../secrets.ts";
+import { kvGetAllKeys, kvMergeAllApiKeysIntoCache } from "../kv/api-keys.ts";
+import { bootstrapCache } from "../kv/flush.ts";
+import { metrics } from "../metrics.ts";
+import { resetKvRateLimitsForTests } from "../rate-limit.ts";
+import { resetProxyStreamCountersForTests } from "../stream-limits.ts";
+import { AppState, state } from "../state.ts";
+import { setLogSinkForTests } from "../logger.ts";
+import type { ApiKey } from "../types.ts";
+
+interface CapturedLog {
+  level: string;
+  record: Record<string, unknown>;
+}
+
+function captureLogs(): { records: CapturedLog[]; restore: () => void } {
+  const records: CapturedLog[] = [];
+  setLogSinkForTests((level, line) => {
+    records.push({ level, record: JSON.parse(line) });
+  });
+  return {
+    records,
+    restore: () => setLogSinkForTests(null),
+  };
+}
+
+async function setupKv(): Promise<Deno.Kv> {
+  if (state.kvFlushTimerId !== null) clearInterval(state.kvFlushTimerId);
+  const kv = await Deno.openKv(":memory:");
+  Deno.env.set("SETUP_TOKEN", "test-setup-token");
+  Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
+  Object.assign(state, new AppState());
+  state.kv = kv;
+  await bootstrapCache();
+  await resetKvRateLimitsForTests();
+  await resetProxyStreamCountersForTests();
+  metrics.reset();
+  return kv;
+}
+
+async function writeGoodRecord(id: string, plaintext: string): Promise<void> {
+  await state.kv.set([...API_KEY_PREFIX, id], {
+    id,
+    encryptedKey: await encryptApiKey(plaintext),
+    useCount: 0,
+    status: "active",
+    createdAt: Date.now(),
+  });
+}
+
+Deno.test(
+  "kvGetAllKeys: skips malformed structure (missing encryptedKey)",
+  async () => {
+    const kv = await setupKv();
+    const logs = captureLogs();
+    try {
+      await writeGoodRecord("good", "sk-good-1");
+      // Legacy-shaped record: has plaintext `key` but no `encryptedKey`.
+      await state.kv.set([...API_KEY_PREFIX, "bad-missing-encrypted"], {
+        id: "bad-missing-encrypted",
+        key: "sk-legacy",
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      });
+
+      const keys = await kvGetAllKeys();
+
+      assertEquals(keys.length, 1);
+      assertEquals(keys[0].id, "good");
+
+      const warns = logs.records.filter(
+        (r) =>
+          r.level === "warn" && r.record.event === "api_key_hydrate_failed",
+      );
+      assertEquals(warns.length, 1);
+      assertEquals(warns[0].record.keyId, "bad-missing-encrypted");
+
+      assertEquals(
+        metrics.snapshot().api_key_hydrate_failed_total?.skipped,
+        1,
+      );
+    } finally {
+      logs.restore();
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvGetAllKeys: skips invalid ciphertext format",
+  async () => {
+    const kv = await setupKv();
+    const logs = captureLogs();
+    try {
+      await writeGoodRecord("good", "sk-good-2");
+      await state.kv.set([...API_KEY_PREFIX, "bad-invalid-cipher"], {
+        id: "bad-invalid-cipher",
+        encryptedKey: "not-encrypted",
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      });
+
+      const keys = await kvGetAllKeys();
+
+      assertEquals(keys.length, 1);
+      assertEquals(keys[0].id, "good");
+
+      const warns = logs.records.filter(
+        (r) =>
+          r.level === "warn" && r.record.event === "api_key_hydrate_failed",
+      );
+      assertEquals(warns.length, 1);
+      assertEquals(warns[0].record.keyId, "bad-invalid-cipher");
+    } finally {
+      logs.restore();
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvGetAllKeys: skips decrypt failure (record encrypted with different secret)",
+  async () => {
+    const kv = await setupKv();
+    const logs = captureLogs();
+    try {
+      await writeGoodRecord("good", "sk-good-3");
+
+      // Generate a ciphertext under a different secret so isEncryptedApiKey()
+      // passes but crypto.subtle.decrypt rejects under the active secret.
+      Deno.env.set("KEY_ENCRYPTION_SECRET", "wrong-secret");
+      const wrongCiphertext = await encryptApiKey("sk-bad");
+      Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
+
+      await state.kv.set([...API_KEY_PREFIX, "bad-decrypt"], {
+        id: "bad-decrypt",
+        encryptedKey: wrongCiphertext,
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      });
+
+      const keys = await kvGetAllKeys();
+
+      assertEquals(keys.length, 1);
+      assertEquals(keys[0].id, "good");
+
+      const warns = logs.records.filter(
+        (r) =>
+          r.level === "warn" && r.record.event === "api_key_hydrate_failed",
+      );
+      assertEquals(warns.length, 1);
+      assertEquals(warns[0].record.keyId, "bad-decrypt");
+    } finally {
+      logs.restore();
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvMergeAllApiKeysIntoCache: bad record no longer blocks good changes",
+  async () => {
+    const kv = await setupKv();
+    const logs = captureLogs();
+    try {
+      // Seed the cache with an "old" key that has since been deleted from KV.
+      const old: ApiKey = {
+        id: "old",
+        key: "sk-old",
+        encryptedKey: await encryptApiKey("sk-old"),
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      };
+      state.cachedKeysById.set(old.id, old);
+
+      await writeGoodRecord("good-new", "sk-good-new");
+      await state.kv.set([...API_KEY_PREFIX, "bad"], {
+        id: "bad",
+        encryptedKey: "not-encrypted",
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      });
+
+      await kvMergeAllApiKeysIntoCache();
+
+      assertEquals(state.cachedKeysById.has("good-new"), true);
+      assertEquals(state.cachedKeysById.has("bad"), false);
+      // "old" is genuinely absent from KV (not skipped) and must be evicted.
+      assertEquals(state.cachedKeysById.has("old"), false);
+      assertEquals(state.cachedActiveKeyIds.includes("good-new"), true);
+    } finally {
+      logs.restore();
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "kvMergeAllApiKeysIntoCache: skipped cached id is not evicted",
+  async () => {
+    const kv = await setupKv();
+    const logs = captureLogs();
+    try {
+      const stable: ApiKey = {
+        id: "cached-bad",
+        key: "sk-stable",
+        encryptedKey: await encryptApiKey("sk-stable"),
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      };
+      state.cachedKeysById.set(stable.id, stable);
+
+      // KV has the same id but the record is unreadable.
+      await state.kv.set([...API_KEY_PREFIX, "cached-bad"], {
+        id: "cached-bad",
+        encryptedKey: "not-encrypted",
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      });
+
+      await kvMergeAllApiKeysIntoCache();
+
+      assertEquals(state.cachedKeysById.has("cached-bad"), true);
+      assertEquals(state.cachedKeysById.get("cached-bad")?.key, "sk-stable");
+    } finally {
+      logs.restore();
+      kv.close();
+    }
+  },
+);
+
+Deno.test(
+  "bootstrapCache: bad record does not block startup",
+  async () => {
+    if (state.kvFlushTimerId !== null) clearInterval(state.kvFlushTimerId);
+    Deno.env.set("SETUP_TOKEN", "test-setup-token");
+    Deno.env.set("KEY_ENCRYPTION_SECRET", "test-key-encryption-secret");
+    Object.assign(state, new AppState());
+    const kv = await Deno.openKv(":memory:");
+    state.kv = kv;
+    metrics.reset();
+    const logs = captureLogs();
+
+    try {
+      await writeGoodRecord("good", "sk-bootstrap");
+      await state.kv.set([...API_KEY_PREFIX, "bad"], {
+        id: "bad",
+        encryptedKey: "not-encrypted",
+        useCount: 0,
+        status: "active",
+        createdAt: Date.now(),
+      });
+
+      await bootstrapCache();
+
+      assertEquals(state.cachedKeysById.has("good"), true);
+      assertEquals(state.cachedKeysById.has("bad"), false);
+    } finally {
+      logs.restore();
+      kv.close();
+    }
+  },
+);

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -13,6 +13,8 @@ import { generateId } from "../utils.ts";
 import { sha256Hex } from "../crypto.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
 import { decryptApiKey, encryptApiKey } from "../secrets.ts";
+import { logger } from "../logger.ts";
+import { metrics } from "../metrics.ts";
 import { state } from "../state.ts";
 import {
   getNextRevisionValue,
@@ -23,26 +25,36 @@ import { waitForKvAtomicRetry } from "./atomic-retry.ts";
 
 async function hydrateApiKey(value: unknown): Promise<ApiKey> {
   const persisted = assertCurrentApiKey(value);
-  return {
-    ...persisted,
-    key: await decryptApiKey(persisted.encryptedKey),
-  };
+  return { ...persisted, key: await decryptApiKey(persisted.encryptedKey) };
 }
-
-export async function kvGetAllKeys(): Promise<ApiKey[]> {
+async function kvGetAllKeysWithSkipped(): Promise<
+  { keys: ApiKey[]; skippedKeyIds: Set<string> }
+> {
   const keys: ApiKey[] = [];
+  const skippedKeyIds = new Set<string>();
   const iter = state.kv.list({ prefix: API_KEY_PREFIX });
   for await (const entry of iter) {
-    keys.push(await hydrateApiKey(entry.value));
+    try {
+      keys.push(await hydrateApiKey(entry.value));
+    } catch (error) {
+      const rawId = entry.key[API_KEY_PREFIX.length];
+      const keyId = typeof rawId === "string" ? rawId : undefined;
+      if (keyId) skippedKeyIds.add(keyId);
+      const fields = { keyId, kvKey: String(entry.key) };
+      logger.warn("api_key_hydrate_failed", fields, error);
+      metrics.inc("api_key_hydrate_failed_total", "skipped");
+    }
   }
-  return keys;
+  return { keys, skippedKeyIds };
 }
-
+export async function kvGetAllKeys(): Promise<ApiKey[]> {
+  return (await kvGetAllKeysWithSkipped()).keys;
+}
 export async function kvMergeAllApiKeysIntoCache(): Promise<void> {
-  const keys = await kvGetAllKeys();
+  const { keys, skippedKeyIds } = await kvGetAllKeysWithSkipped();
   const loadedIds = new Set(keys.map((key) => key.id));
   for (const id of state.cachedKeysById.keys()) {
-    if (!loadedIds.has(id)) {
+    if (!loadedIds.has(id) && !skippedKeyIds.has(id)) {
       state.cachedKeysById.delete(id);
       state.keyCooldownUntil.delete(id);
       state.dirtyKeyIds.delete(id);

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -39,7 +39,7 @@ async function kvGetAllKeysWithSkipped(): Promise<
     } catch (error) {
       const rawId = entry.key[API_KEY_PREFIX.length];
       const keyId = typeof rawId === "string" ? rawId : undefined;
-      if (keyId) skippedKeyIds.add(keyId);
+      if (keyId) skippedKeyIds.add(keyId); // string ids only — must match cachedKeysById to be skip-protected
       const fields = { keyId, kvKey: String(entry.key) };
       logger.warn("api_key_hydrate_failed", fields, error);
       metrics.inc("api_key_hydrate_failed_total", "skipped");


### PR DESCRIPTION
## Summary

- Fixes #144.
- `kvGetAllKeys` now skips individual records that fail hydration (`assertCurrentApiKey` or `decryptApiKey`) and logs `api_key_hydrate_failed` with `keyId`/`kvKey` + increments `api_key_hydrate_failed_total` metric.
- `kvMergeAllApiKeysIntoCache` merges valid records while avoiding accidental eviction of cached ids whose KV records were present but skipped (prevents secret-rotation from wiping the local cache).

## Test plan

- [x] `kvGetAllKeys: skips malformed structure` — missing `encryptedKey` field
- [x] `kvGetAllKeys: skips invalid ciphertext format` — `encryptedKey` not prefixed with `v1$aes-gcm$`
- [x] `kvGetAllKeys: skips decrypt failure` — record encrypted with different secret
- [x] `kvMergeAllApiKeysIntoCache: bad record no longer blocks good changes` — good keys merge, deleted keys evict, bad keys don't block
- [x] `kvMergeAllApiKeysIntoCache: skipped cached id is not evicted` — prevents secret misconfiguration from clearing usable cache
- [x] `bootstrapCache: bad record does not block startup` — cold start resilience
- [x] All 190 existing tests still pass
- [x] `deno task check` / `deno task lint` / `large-files:check` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了 API 密钥加载的容错能力：系统现在能够优雅地跳过损坏或无法解密的密钥记录，而不会阻塞整个加载过程。有效的密钥仍会正常缓存并继续使用，失败的密钥加载会被记录用于监控。

* **Tests**
  * 新增回归测试，验证密钥加载在各类故障场景下的行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->