### PR TITLE
chore(api-keys): trim legacy duplicate cleanup surface

### DIFF
--- a/docs/runbooks/key-and-model-operations.md
+++ b/docs/runbooks/key-and-model-operations.md
@@ -38,47 +38,6 @@ that model from the active pool and retries with the next model. If all
 configured models are removed or unavailable, proxy requests return a model
 availability error.
 
-## Pre-existing duplicate API key cleanup
-
-Deployments that pre-date the value-digest index (issue #139) may contain
-duplicate Cerebras API key records — two or more KV entries with different ids
-but the same plaintext value. On bootstrap, `kvBackfillApiKeyValueIndex` detects
-these and emits a structured warning per duplicate:
-
-```
-level: warn
-event: api_key_value_index_pre_existing_duplicate
-keptId: <canonical id protected by the index>
-duplicateId: <unprotected legacy duplicate>
-```
-
-### Cleanup procedure
-
-1. Delete the `duplicateId` shown in the warning log.
-2. Repeat for each `api_key_value_index_pre_existing_duplicate` warning.
-3. Confirm no duplicate warnings appear on the next bootstrap / deploy.
-4. If both records must be removed, delete all `duplicateId`s first, then
-   `keptId`.
-
-### Why order matters
-
-`keptId` is the canonical record — the value-digest index points at it. If you
-delete `keptId` first:
-
-- `kvDeleteKey` removes the index entry (it only deletes the index when it
-  points at the id being deleted).
-- The `duplicateId` record still exists in KV but now has no index protection.
-- Until the next `kvBackfillApiKeyValueIndex` run (next bootstrap), a same-value
-  `kvAddKey` request can succeed and create yet another duplicate.
-
-This is an accepted migration-period window (issue #146, direction B). The fix
-is operational: always delete the unprotected duplicate first.
-
-### Do not export plaintext keys
-
-Use only the `keptId` / `duplicateId` from the log for cleanup. The admin API
-intentionally returns `403` on plaintext export endpoints.
-
 ## Recovery
 
 - If a key is marked `invalid`, add a replacement key and delete the invalid

--- a/src/__tests__/api-key-duplicate_test.ts
+++ b/src/__tests__/api-key-duplicate_test.ts
@@ -10,7 +10,7 @@ import { assertEquals } from "@std/assert";
 import { API_KEY_PREFIX, API_KEY_VALUE_INDEX_PREFIX } from "../constants.ts";
 import { sha256Hex } from "../crypto.ts";
 import { encryptApiKey } from "../secrets.ts";
-import { kvAddKey, kvDeleteKey, kvGetAllKeys } from "../kv/api-keys.ts";
+import { kvAddKey, kvDeleteKey } from "../kv/api-keys.ts";
 import { kvBackfillApiKeyValueIndex } from "../kv/api-keys-index.ts";
 import { bootstrapCache } from "../kv/flush.ts";
 import { rebuildActiveKeyIds } from "../api-keys.ts";
@@ -225,8 +225,8 @@ Deno.test(
         digest,
       ]);
       // The index points at one of the two records (whichever the list
-      // iteration visited first); the other record is left intact in KV
-      // for an admin to clean up.
+      // iteration visited first); the other record is left intact because
+      // backfill must not choose which user data to discard.
       const winnerId = indexEntry.value;
       assertEquals(typeof winnerId, "string");
       const both = ["dup-keep", "dup-other"];
@@ -423,77 +423,6 @@ Deno.test(
       } finally {
         state.kv.atomic = originalAtomic;
       }
-    } finally {
-      setLogSinkForTests(null);
-      kv.close();
-    }
-  },
-);
-
-Deno.test(
-  "kvDeleteKey: deleting canonical pre-existing duplicate leaves survivor temporarily unprotected",
-  async () => {
-    // Characterization test for issue #146 (direction B): documents the
-    // accepted migration-period window where deleting the canonical id of
-    // a pre-existing duplicate removes the value-index, leaving the
-    // surviving duplicate temporarily unprotected until the next backfill.
-    const kv = await setupKv();
-    try {
-      const plaintext = "sk-pre-existing-delete-window";
-      await persistLegacyApiKey("dup-canonical-window-a", plaintext);
-      await persistLegacyApiKey("dup-canonical-window-b", plaintext);
-
-      const backfill = await kvBackfillApiKeyValueIndex();
-      assertEquals(backfill.created, 1);
-      assertEquals(backfill.preExistingDuplicates, 1);
-
-      const digest = await sha256Hex(plaintext);
-      const indexKey = [...API_KEY_VALUE_INDEX_PREFIX, digest];
-      const indexEntry = await state.kv.get<string>(indexKey);
-      const canonicalId = indexEntry.value as string;
-      const both = ["dup-canonical-window-a", "dup-canonical-window-b"];
-      assertEquals(both.includes(canonicalId), true);
-      const survivorId = both.find((id) => id !== canonicalId)!;
-
-      // Deleting the canonical id removes the index entry.
-      const del = await kvDeleteKey(canonicalId);
-      assertEquals(del.success, true);
-
-      const postDelete = await state.kv.get<string>(indexKey);
-      assertEquals(postDelete.value, null);
-
-      // Survivor's main record is still in KV.
-      const survivorEntry = await state.kv.get(
-        [...API_KEY_PREFIX, survivorId],
-      );
-      assertEquals(survivorEntry.value !== null, true);
-
-      // Simulate a fresh instance: clear local cache so kvAddKey relies
-      // solely on the (now-deleted) value-index for duplicate detection.
-      state.cachedKeysById.clear();
-      state.cachedActiveKeyIds = [];
-      rebuildActiveKeyIds();
-
-      // The window: kvAddKey succeeds because the index is gone, even
-      // though the survivor with the same plaintext still exists in KV.
-      const add = await kvAddKey(plaintext);
-      assertEquals(add.success, true);
-      assertEquals(add.id !== canonicalId, true);
-      assertEquals(add.id !== survivorId, true);
-
-      // The new record now owns the digest index.
-      const postAddIndex = await state.kv.get<string>(indexKey);
-      assertEquals(postAddIndex.value, add.id);
-
-      // Confirm KV now holds two live records with the same plaintext:
-      // the survivor and the newly added record.
-      const hydrated = await kvGetAllKeys();
-      const sameValueIds = hydrated
-        .filter((key) => key.key === plaintext)
-        .map((key) => key.id);
-      assertEquals(sameValueIds.length, 2);
-      assertEquals(sameValueIds.includes(survivorId), true);
-      assertEquals(sameValueIds.includes(add.id!), true);
     } finally {
       setLogSinkForTests(null);
       kv.close();

--- a/src/kv/api-keys-index.ts
+++ b/src/kv/api-keys-index.ts
@@ -26,22 +26,8 @@ export function valueIndexKey(digest: string): Deno.KvKey {
  * - Missing index → atomically create it pointing at the record's id.
  * - Existing index points at this id → no-op.
  * - Existing index points at a different id → log warn but do not
- *   overwrite. The record currently in the index slot is the canonical
- *   (protected) id; the other record is reported as `duplicateId` and
- *   left intact in KV for an admin to clean up. We deliberately avoid
- *   auto-deleting either record from here because a backfill path is the
- *   wrong place to drop user data.
- *
- * Pre-existing duplicate semantics (issue #139, see also #146):
- * - As long as the canonical id still exists, same-value kvAddKey calls
- *   are blocked by the digest index — exactly as if there were no
- *   duplicate.
- * - If an admin deletes the canonical id first, kvDeleteKey removes the
- *   index entry too. The surviving duplicate then has no index protection
- *   until the next kvBackfillApiKeyValueIndex / bootstrap re-indexes it.
- *   In that window, a same-value kvAddKey can succeed and create a fresh
- *   duplicate. Admins should always delete the duplicateId from the warn
- *   log first — see the runbook.
+ *   overwrite or delete either record. A backfill path repairs missing
+ *   indexes; it must not choose which user data to discard.
  *
  * Concurrency: a CAS conflict means another instance won the race for
  * the same digest; treat as success (the entry is now there). Any other

--- a/src/kv/api-keys.ts
+++ b/src/kv/api-keys.ts
@@ -215,14 +215,8 @@ export async function kvDeleteKey(
     .delete(key)
     .set(API_KEY_CACHE_REVISION_KEY, revision);
   if (indexEntry.value === id) {
-    // Delete the digest index only when this record is the indexed
-    // canonical id. If the index points at another id, leave it intact
-    // so that survivor remains protected.
-    //
-    // Legacy duplicate window (#146-B): deleting the canonical id of a
-    // pre-existing duplicate pair removes the digest index. The remaining
-    // duplicate is unprotected until the next backfill / bootstrap;
-    // admins should delete duplicateId before keptId. See the runbook.
+    // Delete the digest index only when this record owns it. If another
+    // id owns the index, leave that duplicate-protection path intact.
     atomic = atomic.delete(indexKey);
   }
   const deleteResult = await atomic.commit();


### PR DESCRIPTION
## 摘要

按 issue #151 的 Option A 先做轻量清理：

- 保留 value-digest index 和 `kvBackfillApiKeyValueIndex`，继续支持缺失 digest index 的冷启动修复。
- 删除 pre-existing duplicate cleanup runbook 章节，避免为当前 fresh deployment 维护不会用到的人工清理流程。
- 删除 #150 加的 canonical-delete window characterization test。
- 简化 `kvBackfillApiKeyValueIndex` / `kvDeleteKey` 注释，只保留当前代码需要表达的 invariant：backfill 不自动丢弃用户数据，delete 只删除当前 id 拥有的 digest index。

这次不做 Option C；后续如果确认不需要支持 pre-index KV 数据升级，再单独切断 legacy migration/backfill 兼容路径。digest index 本身仍是当前 `kvAddKey` 防 stale cache / 多实例同值重复写入的核心 invariant。

## 验证

- `deno test --allow-all src/__tests__/api-key-duplicate_test.ts`
- `deno task fmt:check`
- `deno task check`
- `deno task lint`
- `deno task naming:check`
- `deno task complexity:check`
- `deno task module-boundaries:check`
- `deno task agents:check`
- `deno task large-files:check`
- `deno task tech-debt:check`
- `deno task duplicate-code:check`
- `deno task unused-deps:check`
- `deno task openapi:check`
- `deno task test:ci`
- `deno task coverage:lcov`
- `deno task coverage:check`
- `deno task test:performance`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **文档**
  * 从运行手册中移除了关于API密钥重复处理的文档章节

* **测试**
  * 调整了API密钥重复检测相关的测试用例和注释

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makoMakoGo/thanks-to-cerebras/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->